### PR TITLE
Add __ne__ method to AudioSegment class

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -60,6 +60,9 @@ class AudioSegment(object):
         try: return self._data == other._data
         except: return False
 
+    def __ne__(self, other):
+        return not (self == other)
+
     def __iter__(self):
         return (self[i] for i in xrange(len(self)))
 

--- a/test/test.py
+++ b/test/test.py
@@ -239,6 +239,12 @@ class AudioSegmentTests(unittest.TestCase):
                 'format_test.m4a'), "m4a")
         self.assertTrue(len(seg_m4a))
 
+    def test_equal_and_not_equal(self):
+        wav_file = self.seg1.export(format='wav')
+        wav = AudioSegment.from_wav(wav_file)
+        self.assertTrue(self.seg1 == wav)
+        self.assertFalse(self.seg1 != wav)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
According to [the reference](http://docs.python.org/2/reference/datamodel.html#object.__eq__), when defining `__eq__()`, one should also define `__ne__()` because the truth of `x==y` does not imply that `x!=y` is false. In this case, it seems reasonable to make such implication hold by making `__ne__()` return the inverse of `__eq__()`.
