### PR TITLE
fix bitrate option

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -271,7 +271,7 @@ class AudioSegment(object):
             args.extend(["-acodec", codec])
         
         if bitrate is not None:
-            args.extend(["-b", bitrate])
+            args.extend(["-b:a", bitrate])
             
         if parameters is not None:
             # extend arguments with arbitrary set


### PR DESCRIPTION
In ffmpeg, -b defaults to -b:v, which only deals with video bitrate. Explicitly using -b:a will handle audio bitrate changes and give the desired behavior.

http://ffmpeg.org/ffmpeg.html#Stream-specifiers-1
