### PR TITLE
add libvorbis codec for ogg Vorbis export when no codec is specified

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -318,6 +318,10 @@ class AudioSegment(object):
                        '-y',  # always overwrite existing files
                        "-f", "wav", "-i", data.name,  # input options (filename last)
                        ]
+
+        if format == "ogg" and codec is None:
+            ffmpeg_call.extend(["-acodec", "libvorbis"])
+
         if codec is not None:
             # force audio encoder
             ffmpeg_call.extend(["-acodec", codec])

--- a/test/test.py
+++ b/test/test.py
@@ -172,6 +172,13 @@ class AudioSegmentTests(unittest.TestCase):
 
         self.assertWithinTolerance(len(seg_exported_wav), len(seg), percentage=0.01)
 
+    def test_export_as_ogg(self):
+        seg = self.seg1
+        exported_ogg = seg.export(format='ogg')
+        seg_exported_ogg = AudioSegment.from_ogg(exported_ogg)
+
+        self.assertWithinTolerance(len(seg_exported_ogg), len(seg), percentage=0.01)
+
     def test_export_forced_codec(self):
         seg = self.seg1 + self.seg2
 
@@ -345,12 +352,12 @@ class AudioSegmentTests(unittest.TestCase):
         for chunk in chunks[1:]:
             seg2 += chunk
         self.assertEqual(len(seg), len(seg2))
-        
+
     def test_empty(self):
         self.assertEqual(len(self.seg1), len(self.seg1 + AudioSegment.empty()))
         self.assertEqual(len(self.seg2), len(self.seg2 + AudioSegment.empty()))
         self.assertEqual(len(self.seg3), len(self.seg3 + AudioSegment.empty()))
-        
+
 
     def test_speedup(self):
         speedup_seg = self.seg1.speedup(2.0)


### PR DESCRIPTION
When converting an input audio file to Ogg Vorbis if the codec is not specified as _libvorbis_ the resultant output file is in the FLAC format. I tested this loading an input MP3 and WAV file and then exporting it to Ogg, AU, WAV. For the ogg format no error was raised but the resultant file when checked was actually a FLAC. 

I could convert to mp3 without specifying a codec. Ogg files only resulted when `codec='libvorbis'` was added. I'm a bit pressed for time at the minute so wanted to flag it up; I'm unsure if it's a bug with pydub or elsewhere or just a quirk of the process and thus more a documentation update.

```
In [26]: m = AudioSegment.from_file('/tmp/track.mp3', 'mp3')

In [27]: m = AudioSegment.from_mp3('/tmp/track.mp3')                                                                                                                                                  

In [28]: m.export('/tmp/t.ogg', format='ogg')                                                                                                                                                         
Out[28]: <open file '/tmp/t.ogg', mode 'wb+' at 0x49a4270>

In [29]: !soxi /tmp/t.ogg
soxi FAIL formats: can't open input file `/tmp/t.ogg': Input not an Ogg Vorbis audio stream

In [30]: m.export('/tmp/t.ogg', format='ogg', codec='libvorbis')
Out[30]: <open file '/tmp/t.ogg', mode 'wb+' at 0x49a4300>

In [31]: !soxi /tmp/t.ogg

Input File     : '/tmp/t.ogg'
Channels       : 2
Sample Rate    : 44100
Precision      : 16-bit
Duration       : 00:01:30.02 = 3969856 samples = 6751.46 CDDA sectors
File Size      : 1.21M
Bit Rate       : 108k
Sample Encoding: Vorbis
Comment        : 'encoder=Lavf55.19.104'


In [32]: m.export('/tmp/t.ogg', format='wav')                                                                                                                                                         
Out[32]: <open file '/tmp/t.ogg', mode 'wb+' at 0x49a4390>

In [33]: !soxi /tmp/t.ogg

Input File     : '/tmp/t.ogg' (wav)
Channels       : 2
Sample Rate    : 44100
Precision      : 16-bit
Duration       : 00:01:30.02 = 3969839 samples = 6751.43 CDDA sectors
File Size      : 15.9M
```

I've amended the export method to check if there is no codec and the target is ogg. I also added a new test for `export_as_ogg`. Before the fix this failed, after it passes:

```
python test/test.py 
.......E.........................
======================================================================
ERROR: test_export_as_ogg (__main__.AudioSegmentTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test.py", line 178, in test_export_as_ogg
    seg_exported_ogg = AudioSegment.from_wav(exported_ogg)
  File "/home/jaymz/development/python/pydub/test/pydub/audio_segment.py", line 262, in from_wav
    return cls(data=file)
  File "/home/jaymz/development/python/pydub/test/pydub/audio_segment.py", line 58, in __init__
    raw = wave.open(StringIO(data), 'rb')
  File "/usr/lib/python2.7/wave.py", line 498, in open
    return Wave_read(f)
  File "/usr/lib/python2.7/wave.py", line 163, in __init__
    self.initfp(f)
  File "/usr/lib/python2.7/wave.py", line 130, in initfp
    raise Error, 'file does not start with RIFF id'
Error: file does not start with RIFF id

----------------------------------------------------------------------
Ran 33 tests in 4.263s

FAILED (errors=1)
```

```
python test/test.py 
.................................
----------------------------------------------------------------------
Ran 33 tests in 4.458s

OK
```
