### PR TITLE
overlay loops, matching std audio semantics

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -140,58 +140,65 @@ class AudioSegmentTests(unittest.TestCase):
         self.assertEqual(len(seg_mult), 5000)
         self.assertEqual(len(seg_over), 5000)
 
-    def test_overlay_loops(self):
+    def test_overlay_times(self):
         # infinite
         seg_mult = self.seg1[:5000] * self.seg2[:3000]
-        seg_over = self.seg1[:5000].overlay(self.seg2[:3000], loops=-1)
+        seg_over = self.seg1[:5000].overlay(self.seg2[:3000], times=99999999)
         self.assertEqual(len(seg_mult), len(seg_over))
         self.assertEqual(len(seg_over), 5000)
         self.assertTrue(seg_mult._data == seg_over._data)
 
-        # no looping
+        # no times, no-op
         piece = self.seg2[:1000]
-        seg_manual = self.seg1[:4000].overlay(piece, position=500)
-        seg_over = self.seg1[:4000].overlay(piece, loops=0)
+        seg_manual = self.seg1[:4000]
+        seg_over = self.seg1[:4000].overlay(piece, times=0)
         self.assertEqual(len(seg_manual), len(seg_over))
         self.assertEqual(len(seg_over), 4000)
         self.assertFalse(seg_mult._data == seg_over._data)
 
         # 1 loop
-        seg_manual = self.seg1[:4000].overlay(piece, position=500) \
-            .overlay(piece, position=1500)
-        seg_over = self.seg1[:4000].overlay(piece, loops=1)
+        seg_manual = self.seg1[:4000].overlay(piece, position=500)
+        seg_over = self.seg1[:4000].overlay(piece, times=1)
         self.assertEqual(len(seg_manual), len(seg_over))
         self.assertEqual(len(seg_over), 4000)
         self.assertFalse(seg_mult._data == seg_over._data)
 
         # 2 loops
         seg_manual = self.seg1[:4000].overlay(piece, position=500) \
-            .overlay(piece, position=1500).overlay(piece, position=2500)
-        seg_over = self.seg1[:4000].overlay(piece, loops=2)
+            .overlay(piece, position=1500)
+        seg_over = self.seg1[:4000].overlay(piece, times=2)
         self.assertEqual(len(seg_manual), len(seg_over))
         self.assertEqual(len(seg_over), 4000)
         self.assertFalse(seg_mult._data == seg_over._data)
 
-        # 3 loops (last will pass end)
+        # 3 loops
+        seg_manual = self.seg1[:4000].overlay(piece, position=500) \
+            .overlay(piece, position=1500).overlay(piece, position=2500)
+        seg_over = self.seg1[:4000].overlay(piece, times=3)
+        self.assertEqual(len(seg_manual), len(seg_over))
+        self.assertEqual(len(seg_over), 4000)
+        self.assertFalse(seg_mult._data == seg_over._data)
+
+        # 4 loops (last will pass end)
         seg_manual = self.seg1[:4000].overlay(piece, position=500) \
             .overlay(piece, position=1500).overlay(piece, position=2500) \
             .overlay(piece, position=3500)
-        seg_over = self.seg1[:4000].overlay(piece, loops=3)
+        seg_over = self.seg1[:4000].overlay(piece, times=4)
         self.assertEqual(len(seg_manual), len(seg_over))
         self.assertEqual(len(seg_over), 4000)
         self.assertFalse(seg_mult._data == seg_over._data)
 
-        # 4 loops (last won't happen b/c past end)
+        # 5 loops (last won't happen b/c past end)
         seg_manual = self.seg1[:4000].overlay(piece, position=500) \
             .overlay(piece, position=1500).overlay(piece, position=2500) \
             .overlay(piece, position=3500).overlay(piece, position=3500)
-        seg_over = self.seg1[:4000].overlay(piece, loops=4)
+        seg_over = self.seg1[:4000].overlay(piece, times=5)
         self.assertEqual(len(seg_manual), len(seg_over))
         self.assertEqual(len(seg_over), 4000)
         self.assertFalse(seg_mult._data == seg_over._data)
 
-        # infinite -1, same (as 3 and 4 really)
-        seg_over = self.seg1[:4000].overlay(piece, loops=-1)
+        # ~infinite, same (as 4 and 5 really)
+        seg_over = self.seg1[:4000].overlay(piece, times=999999999)
         self.assertEqual(len(seg_manual), len(seg_over))
         self.assertEqual(len(seg_over), 4000)
         self.assertFalse(seg_mult._data == seg_over._data)


### PR DESCRIPTION
specific loop count in addition to infinite. matches the standard/common
looping semantics of many audio systems. doc'd overlay method with info on
the behavior of the loop & loops parameters (and rest while i was there)
loop param kept and meaning matched to keep backwards compatiblity.
