### PR TITLE
Fix detect silent segment with minimal length

### DIFF
--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -5,7 +5,7 @@ from .utils import (
 
 def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16):
     seg_len = len(audio_segment)
-    
+
     # you can't have a silent portion of a sound that is longer than the sound
     if seg_len < min_silence_len:
         return []
@@ -15,11 +15,11 @@ def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16):
 
     # find silence and add start and end indicies to the to_cut list
     silence_starts = []
-    
+
     # check every (1 sec by default) chunk of sound for silence
     slice_starts = seg_len - min_silence_len
-    
-    for i in range(slice_starts):
+
+    for i in range(slice_starts + 1):
         audio_slice = audio_segment[i:i+min_silence_len]
         if audio_slice.rms < silence_thresh:
             silence_starts.append(i)
@@ -36,13 +36,13 @@ def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16):
 
     for silence_start_i in silence_starts:
         if silence_start_i != prev_i + 1:
-            silent_ranges.append([current_range_start, 
+            silent_ranges.append([current_range_start,
                                   prev_i + min_silence_len])
             current_range_start = silence_start_i
         prev_i = silence_start_i
 
-    silent_ranges.append([current_range_start, 
-                          silence_start_i + min_silence_len])
+    silent_ranges.append([current_range_start,
+                          prev_i + min_silence_len])
 
     return silent_ranges
 
@@ -79,10 +79,10 @@ def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, ke
     """
     audio_segment - original pydub.AudioSegment() object
 
-    min_silence_len - (in ms) minimum length of a silence to be used for 
+    min_silence_len - (in ms) minimum length of a silence to be used for
         a split. default: 1000ms
 
-    silence_thresh - (in dBFS) anything quieter than this will be 
+    silence_thresh - (in dBFS) anything quieter than this will be
         considered silence. default: -16dBFS
 
     keep_silence - (in ms) amount of silence to leave at the beginning
@@ -91,12 +91,12 @@ def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, ke
     """
 
     not_silence_ranges = detect_nonsilent(audio_segment, min_silence_len, silence_thresh)
-    
+
     chunks = []
     for start_i, end_i in not_silence_ranges:
         start_i = max(0, start_i - keep_silence)
         end_i += keep_silence
 
         chunks.append(audio_segment[start_i:end_i])
-        
+
     return chunks

--- a/test/test.py
+++ b/test/test.py
@@ -577,7 +577,12 @@ class SilenceTests(unittest.TestCase):
     def test_detect_completely_silent_segment(self):
         seg = AudioSegment.silent(5000)
         silent_ranges = detect_silence(seg, min_silence_len=1000, silence_thresh=-20)
-        self.assertEqual(silent_ranges, [[0, 4999]])
+        self.assertEqual(silent_ranges, [[0, 5000]])
+
+    def test_detect_tight_silent_segment(self):
+        seg = AudioSegment.silent(1000)
+        silent_ranges = detect_silence(seg, min_silence_len=1000, silence_thresh=-20)
+        self.assertEqual(silent_ranges, [[0, 1000]])
 
     def test_detect_too_long_silence(self):
         seg = AudioSegment.silent(3000)


### PR DESCRIPTION
pydub.silence.detect_silence should detect a silent segment with
lenght equal to min_silence_len, returning the range of the full
segment