### PR TITLE
Fix wave file loading when internal method fails

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -313,7 +313,7 @@ class AudioSegment(object):
             try:
                 return cls._from_safe_wav(file)
             except:
-                pass
+                file.seek(0)
 
         input_file = NamedTemporaryFile(mode='wb', delete=False)
         input_file.write(file.read())


### PR DESCRIPTION
When `_from_safe_wav()` fails to load the file (I had some problems with wave format extensible files), it does not rewind the file pointer for further ffmpeg/avconv processing.