### PR TITLE
Handle str-typed empty return from readframes.

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -114,7 +114,7 @@ class AudioSegment(object):
             self.frame_width = self.channels * self.sample_width
 
             raw.rewind()
-            self._data = raw.readframes(float('inf'))
+            self._data = raw.readframes(float('inf')) or b''
 
         super(AudioSegment, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
There's a [bug](http://bugs.python.org/issue24608) in python3.4's `wave` library that leads to `readframes()` returning a str (specifically `''`), not bytes.

This leads to a crash when trying to pass data back to `writeframes()`.

This is a workaround to the problem.