### PR TITLE
Adding a method to create an AudioSegment from a data buffer

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -395,8 +395,43 @@ class AudioSegment(object):
         return cls.from_file(file, 'wav')
 
     @classmethod
-    def from_raw(cls, data, **kwargs):
-        return cls.from_file(data, 'raw', sample_width=kwargs['sample_width'], frame_rate=kwargs['frame_rate'], channels=kwargs['channels'])
+    def from_raw(cls, file, **kwargs):
+        return cls.from_file(file, 'raw', sample_width=kwargs['sample_width'], frame_rate=kwargs['frame_rate'], channels=kwargs['channels'])
+    
+    @classmethod
+    def from_data(cls, data, sample_width, frame_rate, channels):
+        """
+        Build an AudioSegment from a buffer of data.
+        
+        **Parameters:**
+        
+        `data`, string: audio data
+        
+        `sample_width`, int: size in bytes of one single sample
+        
+        `frame_rate`, int : number of audio frames per second of audio data
+        
+        `channels`, int: number of channels
+        
+        Note that `data` must contain a integer number of frames, so `len(data)` must a multiple of `(sample_width * channels)`.
+        """ 
+        
+        if not isinstance(data, basestring):
+            raise TypeError("data must be a string buffer")
+        
+        if len(data) % (sample_width * channels) != 0:
+            raise ValueError("data length must be a multiple of (sample_width * channels)")
+        
+        metadata = {
+            'sample_width': sample_width,
+            'frame_rate': frame_rate,
+            'channels': channels,
+            'frame_width': channels * sample_width
+        }
+        return cls(data=data, metadata=metadata)
+        
+        
+        
 
     @classmethod
     def _from_safe_wav(cls, file):

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -416,7 +416,7 @@ class AudioSegment(object):
 
     @classmethod
     def from_raw(cls, file, **kwargs):
-        return cls.from_file(data, 'raw', sample_width=kwargs['sample_width'], frame_rate=kwargs['frame_rate'], channels=kwargs['channels'])
+        return cls.from_file(file, 'raw', sample_width=kwargs['sample_width'], frame_rate=kwargs['frame_rate'], channels=kwargs['channels'])
           
     @classmethod
     def _from_safe_wav(cls, file):

--- a/pydub/exceptions.py
+++ b/pydub/exceptions.py
@@ -21,3 +21,6 @@ class CouldntDecodeError(Exception):
     
 class CouldntEncodeError(Exception):
     pass
+
+class MissingAudioParameter(Exception):
+    pass

--- a/test/test.py
+++ b/test/test.py
@@ -17,6 +17,7 @@ from pydub.exceptions import (
     InvalidID3TagVersion,
     InvalidDuration,
     CouldntDecodeError,
+    MissingAudioParameter,
 )
 from pydub.silence import (
     detect_silence,
@@ -761,23 +762,33 @@ class NoConverterTests(unittest.TestCase):
         func = partial(AudioSegment.from_file, self.mp3_file, format="mp3")
         self.assertRaises(OSError, func)
     
-    def test_creating_AudioSegment_from_data(self):
-        seg = AudioSegment.from_data("\0" * 34, sample_width=2, frame_rate=4, channels=1)
+    def test_init_AudioSegment_data_buffer(self):
+        seg = AudioSegment(data = "\0" * 34, sample_width=2, frame_rate=4, channels=1)
         
         self.assertEqual(seg.duration_seconds, 4.25)
         
         self.assertEqual(seg.sample_width, 2)
         
         self.assertEqual(seg.frame_rate, 4)
+    
+    
+    def test_init_AudioSegment_data_buffer_with_missing_args_fails(self):
+        
+        func = partial(AudioSegment, data = "\0" * 16, sample_width=2, frame_rate=2)
+        self.assertRaises(MissingAudioParameter, func)
+        
+        func = partial(AudioSegment, data = "\0" * 16, sample_width=2, channels=1)
+        self.assertRaises(MissingAudioParameter, func)
+        
+        func = partial(AudioSegment, data = "\0" * 16, frame_rate=2, channels=1)
+        self.assertRaises(MissingAudioParameter, func)
         
     
-    def test_creating_AudioSegment_from_data_with_bad_values_fails(self):
+    def test_init_AudioSegment_data_buffer_with_bad_values_fails(self):
         
-        func = partial(AudioSegment.from_data, "\0" * 14, sample_width=4, frame_rate=2, channels=1)
+        func = partial(AudioSegment, data = "\0" * 14, sample_width=4, frame_rate=2, channels=1)
         self.assertRaises(ValueError, func)
     
-        
-        
 
     def test_exporting(self):
         seg = AudioSegment.from_wav(self.wave_file)

--- a/test/test.py
+++ b/test/test.py
@@ -760,6 +760,24 @@ class NoConverterTests(unittest.TestCase):
 
         func = partial(AudioSegment.from_file, self.mp3_file, format="mp3")
         self.assertRaises(OSError, func)
+    
+    def test_creating_AudioSegment_from_data(self):
+        seg = AudioSegment.from_data(b"\0" * 34, sample_width=2, frame_rate=4, channels=1)
+        
+        self.assertEqual(seg.duration_seconds, 4.25)
+        
+        self.assertEqual(seg.sample_width, 2)
+        
+        self.assertEqual(seg.frame_rate, 4)
+        
+    
+    def test_creating_AudioSegment_from_data_with_bad_values_fails(self):
+        
+        func = partial(AudioSegment.from_data, b"\0" * 14, sample_width=4, frame_rate=2, channels=1)
+        self.assertRaises(ValueError, func)
+    
+        
+        
 
     def test_exporting(self):
         seg = AudioSegment.from_wav(self.wave_file)

--- a/test/test.py
+++ b/test/test.py
@@ -762,7 +762,7 @@ class NoConverterTests(unittest.TestCase):
         self.assertRaises(OSError, func)
     
     def test_creating_AudioSegment_from_data(self):
-        seg = AudioSegment.from_data(b"\0" * 34, sample_width=2, frame_rate=4, channels=1)
+        seg = AudioSegment.from_data("\0" * 34, sample_width=2, frame_rate=4, channels=1)
         
         self.assertEqual(seg.duration_seconds, 4.25)
         
@@ -773,7 +773,7 @@ class NoConverterTests(unittest.TestCase):
     
     def test_creating_AudioSegment_from_data_with_bad_values_fails(self):
         
-        func = partial(AudioSegment.from_data, b"\0" * 14, sample_width=4, frame_rate=2, channels=1)
+        func = partial(AudioSegment.from_data, "\0" * 14, sample_width=4, frame_rate=2, channels=1)
         self.assertRaises(ValueError, func)
     
         


### PR DESCRIPTION
Hi there,

I realized that there is no method to create an AudioSegment from raw data in memory. `from_raw` was a bit misleading because it has a `data` argument which turned out to be a path to a file (just like the one in `from_wav`, `from_ogg`, etc.). So I renamed it to `file` and created a `from_data` method to get an AudioSegment from a string buffer.


Cheers,
Amine