### PR TITLE
Fixed read error when initializing `bytes` data in Python 3

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -127,7 +127,7 @@ class AudioSegment(object):
                 setattr(self, attr, val)
         else:
             # normal construction
-            data = data if isinstance(data, basestring) else data.read()
+            data = data if isinstance(data, basestring) or isinstance(data, bytes) else data.read()
             raw = wave.open(StringIO(data), 'rb')
 
             raw.rewind()


### PR DESCRIPTION
The original code will throw `AttributeError: 'bytes' object has no attribute 'read'` when initializing `pydub.AudioSegment` with a `bytes` object in Python 3. Since your code indends to support Python 3 by using `BytesIO` (aliased into `StringIO`), `pydub.AudioSegment` should have accepted `bytes` data. 

The problematic line of code is [this](https://github.com/jiaaro/pydub/blob/d6190c21b85fdff4ddd58153ab05d609c34cea69/pydub/audio_segment.py#L130):

```
data = data if isinstance(data, basestring) else data.read()
```

It only checks if `data` is `basestring`, which does not exist in Python 3. If data is of `bytes` in Python 3, it will go to `else` part and failed.

Since you didn't use `six`, I added an extra `isinstance` check here to make the code change as minimal as possible, though it may not be a good enough.

FYI, my code which complains about this is [here](https://github.com/shichao-an/soundmeter/blob/94c61b033fa9015ce2a14e865be4617c9504f84c/soundmeter/meter.py#L126), and the error output is:

```
$ ./run.py
Traceback (most recent call last):
  File "./run.py", line 5, in <module>
    main()
  File "/Users/shichao/Documents/projects/soundmeter/soundmeter/meter.py", line 315, in main
    m.start()
  File "/Users/shichao/Documents/projects/soundmeter/soundmeter/meter.py", line 126, in start
    segment = pydub.AudioSegment(data)
  File "/Users/shichao/envs/soundmeter3.4/lib/python3.4/site-packages/pydub/audio_segment.py", line 130, in __init__
    data = data if isinstance(data, basestring) else data.read()
AttributeError: 'bytes' object has no attribute 'read'
```