### PR TITLE
Implement radd to support sum builtin

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -268,6 +268,8 @@ class AudioSegment(object):
         """
         if rarg == 0:
             return self
+        else:
+            return self.__add__(rarg)
 
     def __sub__(self, arg):
         if isinstance(arg, AudioSegment):

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -268,8 +268,8 @@ class AudioSegment(object):
         """
         if rarg == 0:
             return self
-        else:
-            return self.__add__(rarg)
+        raise TypeError("Gains must be the second addend after the "
+                        "AudioSegment")
 
     def __sub__(self, arg):
         if isinstance(arg, AudioSegment):

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -109,9 +109,9 @@ class AudioSegment(object):
         self.sample_width = kwargs.pop("sample_width", None)
         self.frame_rate = kwargs.pop("frame_rate", None)
         self.channels = kwargs.pop("channels", None)
-        
+
         audio_params = (self.sample_width, self.frame_rate, self.channels)
-        
+
         # prevent partial specification of arguments
         if any(audio_params) and None in audio_params:
             raise MissingAudioParameter("Either all audio parameters or no parameter must be specified")
@@ -120,9 +120,9 @@ class AudioSegment(object):
         elif self.sample_width is not None:
             if len(data) % (self.sample_width * self.channels) != 0:
                 raise ValueError("data length must be a multiple of '(sample_width * channels)'")
-            
+
             self.frame_width = self.channels * self.sample_width
-            self._data = data  
+            self._data = data
 
         # keep support for 'metadata' until audio params are used everywhere
         elif kwargs.get('metadata', False):
@@ -163,25 +163,25 @@ class AudioSegment(object):
             self.frame_width = self.channels * self.sample_width
 
         super(AudioSegment, self).__init__(*args, **kwargs)
-    
+
     @property
     def raw_data(self):
         """
         public access to the raw audio data as a bytestring
         """
         return self._data
-        
+
 
     def get_array_of_samples(self):
         """
         returns the raw_data as an array of samples
         """
         return array.array(self.array_type, self._data)
-    
+
     @property
     def array_type(self):
         return get_array_type(self.sample_width * 8)
-    
+
     def __len__(self):
         """
         returns the length of this audio segment in milliseconds
@@ -261,6 +261,13 @@ class AudioSegment(object):
             return self.append(arg, crossfade=0)
         else:
             return self.apply_gain(arg)
+
+    def __radd__(self, rarg):
+        """
+        Permit use of sum() builtin with an iterable of AudioSegments
+        """
+        if rarg == 0:
+            return self
 
     def __sub__(self, arg):
         if isinstance(arg, AudioSegment):
@@ -368,7 +375,7 @@ class AudioSegment(object):
         if format:
             format = format.lower()
             format = AUDIO_FILE_EXT_ALIASES.get(format, format)
-            
+
         def is_format(f):
             f = f.lower()
             if format == f:
@@ -452,7 +459,7 @@ class AudioSegment(object):
     @classmethod
     def from_raw(cls, file, **kwargs):
         return cls.from_file(file, 'raw', sample_width=kwargs['sample_width'], frame_rate=kwargs['frame_rate'], channels=kwargs['channels'])
-          
+
     @classmethod
     def _from_safe_wav(cls, file):
         file = _fd_or_path_or_tempfile(file, 'rb', tempfile=False)

--- a/test/test.py
+++ b/test/test.py
@@ -127,6 +127,20 @@ class AudioSegmentTests(unittest.TestCase):
         self.assertEqual(len(merged1), len(self.seg1) + len(self.seg3) - 100)
         self.assertEqual(len(merged2), len(self.seg2) + len(self.seg3) - 100)
 
+    def test_sum(self):
+        def gen():
+            yield self.seg1
+            yield self.seg2
+            yield self.seg3
+
+        try:
+            summed = sum(gen())
+        except TypeError as e:
+            if "unsupported operand" in str(e):
+                self.fail("Could not sum() audio segments.")
+            else:
+                raise
+
     def test_volume_with_add_sub(self):
         quieter = self.seg1 - 6
         self.assertAlmostEqual(ratio_to_db(quieter.rms, self.seg1.rms),
@@ -242,7 +256,7 @@ class AudioSegmentTests(unittest.TestCase):
         for part in short:
             rebuilt1 += part
 
-        rebuilt2 = sum([part for part in short], short[:0])
+        rebuilt2 = sum([part for part in short])
 
         self.assertTrue(short._data == rebuilt1._data)
         self.assertTrue(short._data == rebuilt2._data)
@@ -662,18 +676,18 @@ class AudioSegmentTests(unittest.TestCase):
         sine_minus_3_dbfs = Sine(1000).to_audio_segment(volume=-3.0)
         self.assertAlmostEqual(-0.0, sine_0_dbfs.max_dBFS, 2)
         self.assertAlmostEqual(-3.0, sine_minus_3_dbfs.max_dBFS, 2)
-        
+
     def test_array_type(self):
         self.assertEqual(self.seg1.array_type, "h")
         self.assertEqual(self.seg2.array_type, "h")
         self.assertEqual(self.seg3.array_type, "h")
         self.assertEqual(self.mp3_seg_party.array_type, "h")
-        
+
         silence = AudioSegment.silent(50)
         self.assertEqual(silence.array_type, "h")
         self.assertEqual(silence.set_sample_width(1).array_type, "b")
         self.assertEqual(silence.set_sample_width(4).array_type, "i")
-    
+
     def test_sample_array(self):
         samples = Sine(450).to_audio_segment().get_array_of_samples()
         self.assertEqual(
@@ -806,34 +820,34 @@ class NoConverterTests(unittest.TestCase):
 
         func = partial(AudioSegment.from_file, self.mp3_file, format="mp3")
         self.assertRaises(OSError, func)
-    
+
     def test_init_AudioSegment_data_buffer(self):
         seg = AudioSegment(data = "\0" * 34, sample_width=2, frame_rate=4, channels=1)
-        
+
         self.assertEqual(seg.duration_seconds, 4.25)
-        
+
         self.assertEqual(seg.sample_width, 2)
-        
+
         self.assertEqual(seg.frame_rate, 4)
-    
-    
+
+
     def test_init_AudioSegment_data_buffer_with_missing_args_fails(self):
-        
+
         func = partial(AudioSegment, data = "\0" * 16, sample_width=2, frame_rate=2)
         self.assertRaises(MissingAudioParameter, func)
-        
+
         func = partial(AudioSegment, data = "\0" * 16, sample_width=2, channels=1)
         self.assertRaises(MissingAudioParameter, func)
-        
+
         func = partial(AudioSegment, data = "\0" * 16, frame_rate=2, channels=1)
         self.assertRaises(MissingAudioParameter, func)
-        
-    
+
+
     def test_init_AudioSegment_data_buffer_with_bad_values_fails(self):
-        
+
         func = partial(AudioSegment, data = "\0" * 14, sample_width=4, frame_rate=2, channels=1)
         self.assertRaises(ValueError, func)
-    
+
 
     def test_exporting(self):
         seg = AudioSegment.from_wav(self.wave_file)


### PR DESCRIPTION
By adding an `__radd__` method that looks if the other argument is 0 (the initialized state of `sum()`'s accumulator), it permits straightforward use of the `sum()` builtin. It even slightly simplified one of the [test cases](https://github.com/jiaaro/pydub/compare/master...nicktimko:simple-sum?expand=1#diff-3eb4d995269f8dd7de58cb236d151d7bR259).

Sorry about all the whitespace changes...my editor chops trailing whitespace. If it's a problem I could fix it.