### PR TITLE
Allow unicode strings in export() tags.

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -568,14 +568,18 @@ class AudioSegment(object):
                 raise InvalidTag("Tags must be a dictionary.")
             else:
                 # Extend converter command with tags.
-                # Make sure we can handle unicode strings.
+                # Make sure we can handle unicode strings in Python
+                # 2.x (In Python 3, these are handled correctly by 
+                # default.)
                 def encode_unicode(s):
-                    """ Leaves simple non-unicode strings untouched.
-                    Converts unicode strings to non-unicode strings by
-                    encoding them in the default encoding of the file
-                    system.
+                    """ In Python 3: leaves all input untouched. 
+                    In Python 2.x: Leaves simple non-unicode strings 
+                    untouched. Converts unicode strings to non-unicode
+                    strings by encoding them in the default encoding 
+                    of the file system.
                     """
-                    if isinstance(s, unicode):
+                    if sys.version_info[0] < 3 \
+                            and isinstance(s, unicode):
                         s = s.encode(sys.getfilesystemencoding())
                     return s
 

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -567,11 +567,22 @@ class AudioSegment(object):
             if not isinstance(tags, dict):
                 raise InvalidTag("Tags must be a dictionary.")
             else:
-                # Extend converter command with tags
-                # print(tags)
+                # Extend converter command with tags.
+                # Make sure we can handle unicode strings.
+                def encode_unicode(s):
+                    """ Leaves simple non-unicode strings untouched.
+                    Converts unicode strings to non-unicode strings by
+                    encoding them in the default encoding of the file
+                    system.
+                    """
+                    if isinstance(s, unicode):
+                        s = s.encode(sys.getfilesystemencoding())
+                    return s
+
                 for key, value in tags.items():
-                    conversion_command.extend(
-                        ['-metadata', u'{0}={1}'.format(key, value)])
+                    pair = '{0}={1}'.format(encode_unicode(key),
+                                            encode_unicode(value))
+                    conversion_command.extend(['-metadata', pair])
 
                 if format == 'mp3':
                     # set id3v2 tag version

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -571,7 +571,7 @@ class AudioSegment(object):
                 # print(tags)
                 for key, value in tags.items():
                     conversion_command.extend(
-                        ['-metadata', '{0}={1}'.format(key, value)])
+                        ['-metadata', u'{0}={1}'.format(key, value)])
 
                 if format == 'mp3':
                     # set id3v2 tag version


### PR DESCRIPTION
Tested locally (win10 64bit, python 2.7.11)
Existing functionality has not been changed.