### PR TITLE
- make _spawn() support subclasses of AudioSegment

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -332,7 +332,7 @@ class AudioSegment(object):
             'channels': self.channels
         }
         metadata.update(overrides)
-        return AudioSegment(data=data, metadata=metadata)
+        return self.__class__(data=data, metadata=metadata)
 
     @classmethod
     def _sync(cls, seg1, seg2):


### PR DESCRIPTION
`AudioSegment._spawn()` is currently hardcoded to return direct instances of `AudioSegment`.

No harm (at least according to tests) is done to allow subclassing, which makes `seg1 + seg2` return an instance of `seg1`.

One might also want to fix `__radd__()` to handle the situation when the subclass is on the right side (i.e. `seg2`), but I don't understand the current `__radd__()` enough to do this.