### PR TITLE
Add flag for Darwin systems to address ffmpeg bug #2697

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -582,6 +582,9 @@ class AudioSegment(object):
                         "-id3v2_version",  id3v2_version
                     ])
 
+        if sys.platform == 'darwin':
+            conversion_command.extend(["-write_xing", "0"])
+
         conversion_command.extend([
             "-f", format, output.name,  # output options (filename last)
         ])


### PR DESCRIPTION
This PR addresses an issue with ffmpeg on Mac/Darwin systems which incorrectly changes (in my case, doubles) the reported duration of audio files exported to .mp3 format with ffmpeg (see https://trac.ffmpeg.org/ticket/2697).

This fix has been tested on Mac OS 10.7.X (Lion) and 10.11.X (Yosemite) with fresh installs of ffmpeg via Homebrew.