### PR TITLE
Add support for IPython

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,5 +40,8 @@ Johan Lövgren
 Joachim Krüger
     github: jkrgr
     
-Shichao An:
-	github: shichao-an
+Shichao An
+    github: shichao-an
+
+Michael Bortnyck
+    github: mbortnyck

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -8,6 +8,7 @@ import wave
 import sys
 import struct
 from .logging_utils import log_conversion
+import base64
 
 try:
     from StringIO import StringIO
@@ -921,5 +922,15 @@ class AudioSegment(object):
             data=audioop.reverse(self._data, self.sample_width)
         )
 
+    def _repr_html_(self):
+            src = """
+                    <audio controls>
+                        <source src="data:audio/wav;base64,{base64}" type="audio/wav" />
+                        Your browser does not support the audio element.
+                    </audio>
+                  """
+            fh = self.export()
+            data = base64.b64encode(fh.read()).decode('ascii')
+            return src.format(base64=data)
 
 from . import effects

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -925,7 +925,7 @@ class AudioSegment(object):
     def _repr_html_(self):
             src = """
                     <audio controls>
-                        <source src="data:audio/wav;base64,{base64}" type="audio/wav" />
+                        <source src="data:audio/mpeg;base64,{base64}" type="audio/mpeg"/>
                         Your browser does not support the audio element.
                     </audio>
                   """


### PR DESCRIPTION
My stab at adding a display function for IPython as discussed in [#127](https://github.com/jiaaro/pydub/issues/127). Uses AudioSegment's export() to create a temporary file, which is then encoded to base64 and passed to an HTML audio element. I experimented some with exporting as wav, but it slowed down the creation of the audio element significantly. @nicktimko had expressed concern that large clips may take too long to dump/display, would it be possible to only load the audio file when the play button is activated so that quality is not compromised too hard?