### PR TITLE
Added ability to invert the phase of only one channel

### DIFF
--- a/pydub/effects.py
+++ b/pydub/effects.py
@@ -201,10 +201,10 @@ def invert_phase(seg, channels=(1, 1)):
         return seg._spawn(data=inverted)
     
     else:
-        if seg.channels == 1:
-            left = right = seg
-        elif seg.channels == 2:
+        if seg.channels == 2:
             left, right = seg.split_to_mono()
+        else:
+            raise Exception("Can't implicitly convert an AudioSegment with " + str(seg.channels) + " channels to stereo.")
             
         if channels == (1, 0):    
             left = left.invert_phase()

--- a/pydub/effects.py
+++ b/pydub/effects.py
@@ -211,14 +211,8 @@ def invert_phase(seg, channels=(1, 1)):
         else:
             right = right.invert_phase()
         
-        left_data = audioop.tostereo(left._data, left.sample_width, 1, 0)
-        right_data = audioop.tostereo(right._data, right.sample_width, 0, 1)
+        return seg.from_mono_audiosegments(left, right)
         
-        output = audioop.add(left_data, right_data, seg.sample_width)
-        
-        return seg._spawn(data=output,
-                    overrides={'channels': 2,
-                               'frame_width': 2 * seg.sample_width})
 
 
 # High and low pass filters based on implementation found on Stack Overflow:

--- a/test/test.py
+++ b/test/test.py
@@ -744,7 +744,7 @@ class AudioSegmentTests(unittest.TestCase):
         self.assertFalse(s_mono == s_inv_right)
         self.assertFalse(s_inv == s_inv_right)
         self.assertTrue(left == s_mono)
-        self.assertFalse(left == s_mono)
+        self.assertFalse(right == s_mono)
         
         s_inv_left = s.invert_phase(channels=(1,0))
         left, right = s_inv_left.split_to_mono()

--- a/test/test.py
+++ b/test/test.py
@@ -727,6 +727,23 @@ class AudioSegmentTests(unittest.TestCase):
         self.assertTrue(s.rms == s_inv.rms)
         self.assertTrue(s == s_inv.invert_phase())
 
+        s_inv_right = s.invert_phase(channels=(0,1))
+        left, right = s_inv_right.split_to_mono()
+        self.assertFalse(s == s_inv_right)
+        self.assertFalse(s_inv == s_inv_right)
+        self.assertTrue(right == s_inv)
+        self.assertFalse(left == s_inv)
+        
+        s_inv_left = s.invert_phase(channels=(1,0))
+        left, right = s_inv_left.split_to_mono()
+        self.assertFalse(s == s_inv_left)
+        self.assertFalse(s_inv == s_inv_left)
+        self.assertTrue(left == s_inv)
+        self.assertFalse(right == s_inv)
+        
+        self.assertFalse(s_inv_left == s_inv_right)
+        
+
     def test_max_dBFS(self):
         sine_0_dbfs = Sine(1000).to_audio_segment()
         sine_minus_3_dbfs = Sine(1000).to_audio_segment(volume=-3.0)

--- a/test/test.py
+++ b/test/test.py
@@ -721,28 +721,39 @@ class AudioSegmentTests(unittest.TestCase):
         self.assertEqual(0, len(self.seg1[0:0]))
 
     def test_invert(self):
-        s = Sine(100).to_audio_segment()
+        s_mono = Sine(100).to_audio_segment()
+        s = s_mono.set_channels(2)
+        
+        try:
+            s_mono.invert_phase(channels=(1, 0))
+        except Exception:
+            pass
+        else:
+            raise Exception("AudioSegment.invert_phase() didn't catch a bad input (mono)")
+        
+            
         s_inv = s.invert_phase()
         self.assertFalse(s == s_inv)
         self.assertTrue(s.rms == s_inv.rms)
         self.assertTrue(s == s_inv.invert_phase())
+        
 
         s_inv_right = s.invert_phase(channels=(0,1))
         left, right = s_inv_right.split_to_mono()
-        self.assertFalse(s == s_inv_right)
+        
+        self.assertFalse(s_mono == s_inv_right)
         self.assertFalse(s_inv == s_inv_right)
-        self.assertTrue(right == s_inv)
-        self.assertFalse(left == s_inv)
+        self.assertTrue(left == s_mono)
+        self.assertFalse(left == s_mono)
         
         s_inv_left = s.invert_phase(channels=(1,0))
         left, right = s_inv_left.split_to_mono()
-        self.assertFalse(s == s_inv_left)
+        
+        self.assertFalse(s_mono == s_inv_left)
         self.assertFalse(s_inv == s_inv_left)
-        self.assertTrue(left == s_inv)
-        self.assertFalse(right == s_inv)
-        
-        self.assertFalse(s_inv_left == s_inv_right)
-        
+        self.assertFalse(left == s_mono)
+        self.assertTrue(right == s_mono)
+            
 
     def test_max_dBFS(self):
         sine_0_dbfs = Sine(1000).to_audio_segment()


### PR DESCRIPTION
What it says on the tin.
Since reversing the phase of only one channel requires use of audioop, I figured it would be better to extend the invert_phase function within pydub rather than add that functionality in an external program. 

This shouldn't break any existing programs using Pydub since it will behave in exactly the same way as it did before if no arguments are passed.