### PR TITLE
Adds volume adjustment during an overlay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "pypy"
+  - "pypy2.7-5.8.0"
 script:
   - python test/test.py

--- a/API.markdown
+++ b/API.markdown
@@ -362,6 +362,8 @@ played_togther = sound1.overlay(sound2)
 
 sound2_starts_after_delay = sound1.overlay(sound2, position=5000)
 
+volume_of_sound1_reduced_during_overlay = sound1.overlay(sound2, gain_during_overlay=-8)
+
 sound2_repeats_until_sound1_ends = sound1.overlay(sound2, loop=true)
 
 sound2_plays_twice = sound1.overlay(sound2, times=2)

--- a/AUTHORS
+++ b/AUTHORS
@@ -57,3 +57,6 @@ Thiago Abdnur
     
 Aurélien Ooms
     github: aureooms
+
+Mike Mattozzi
+    github: mmattozzi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.20.0
+- Add new parameter `gain_during_overlay` to `pydub.AudioSegment.overlay` which allows users to adjust the volume of the target AudioSegment during the portion of the segment which is overlaid with the additional AudioSegment. 
+
 # v0.19.0
 - Allow codec and ffmpeg/avconv parameters to be set in the `pydub.AudioSegment.from_file()` for more control while decoding audio files
 - Allow `AudioSegment` objects with more than two channels to be split using `pydub.AudioSegment().split_to_mono()`

--- a/test/test.py
+++ b/test/test.py
@@ -246,6 +246,21 @@ class AudioSegmentTests(unittest.TestCase):
         self.assertEqual(len(seg_over), 4000)
         self.assertFalse(seg_mult._data == seg_over._data)
 
+    def test_overlay_with_gain_change(self):
+        # Use overlay silence with volume change
+        seg_one = self.seg1[:5000]
+        seg_silent = AudioSegment.silent(duration=2000)
+        seg_over = seg_one.overlay(seg_silent, gain_during_overlay=-7)
+
+        # Manually lower first segment
+        seg_one_lower = seg_one - 7
+        seg_manual = seg_one_lower[:2000] + seg_one[2000:]
+
+        self.assertEqual(len(seg_over), len(seg_manual))
+        self.assertAlmostEqual(seg_over.dBFS, seg_manual.dBFS)
+        self.assertEqual(len(seg_manual), 5000)
+        self.assertEqual(len(seg_over), 5000)
+
     def test_slicing(self):
         empty = self.seg1[:0]
         second_long_slice = self.seg1[:1000]


### PR DESCRIPTION
It seemed like it would be convenient to add a way to do [ducking](https://en.wikipedia.org/wiki/Ducking) when using the overlay function. I added a parameter called `self_volume_change` which can be used to increase or decrease the volume of the audio segment that is being overlaid upon. The volume is only adjusted during the time period when the overlay is applied. This seems easier for a user than having to chop up the audio segment themselves to get the same effect. The common case, I think, would be to provide a negative db value. It seems to work well, although it doesn't do any fancy fading or anything. 

I'm open to a name change for the parameter, I wasn't quite sure what to call it. 

Also, I added a test, but it's kind of lame. I thought a better test would be to overlay silence onto a segment with a negative volume change and see if I could create a byte for byte replica doing this the "manual way". 

Example:
```
def test_overlay_with_volume_change_compare(self):
        # Use overlay silence with volume change
        seg_one = self.seg1[:5000]
        seg_silent = AudioSegment.silent(duration=2000)
        seg_over = seg_one.overlay(seg_silent, self_volume_change=-7)

        # Manually lower first segment
        seg_one_lower = seg_one - 7
        seg_manual = seg_one_lower[:2000] + seg_one[2000:]

        self.assertEqual(len(seg_over), len(seg_manual))

        # Compare each byte of data
        diff = [i for i in xrange(len(seg_over._data)) if seg_over._data[i] != seg_manual._data[i]]
        self.assertEqual(len(diff), 0)
```

What I found comparing the data was that I would get very minor differences, out of KBs of data, there'd be 7 characters different. Not sure if there's something innate about the way the audio is generated or manipulated that makes this type of test impossible. If you think this is a good idea and have thoughts on how to make my testing better, let me know. 