### PR TITLE
Hide banner when playing audio with ffplay

### DIFF
--- a/pydub/playback.py
+++ b/pydub/playback.py
@@ -16,7 +16,7 @@ PLAYER = get_player_name()
 def _play_with_ffplay(seg):
     with NamedTemporaryFile("w+b", suffix=".wav") as f:
         seg.export(f.name, "wav")
-        subprocess.call([PLAYER, "-nodisp", "-autoexit", f.name])
+        subprocess.call([PLAYER, "-nodisp", "-autoexit", "-hide_banner", f.name])
 
 
 def _play_with_pyaudio(seg):


### PR DESCRIPTION
Suppress printing banner when playing audio with `ffplay`.

That's a usability issue, I guess.
The banner takes up a lot of lines and is really distracting, especially inside IPython.