### PR TITLE
Optimize AudioSegment.fade

### DIFF
--- a/API.markdown
+++ b/API.markdown
@@ -415,7 +415,7 @@ fade_quieter_beteen_2_and_3_seconds = sound1.fade(to_gain=-3.5, start=2000, end=
 
 # easy way is to use the .fade_in() convenience method. note: -120dB is basically silent.
 fade_in_the_hard_way = sound1.fade(from_gain=-120.0, start=0, duration=5000)
-fade_out_the_hard_way = sound1.fade(to_gain=-120.0, end=0, duration=5000)
+fade_out_the_hard_way = sound1.fade(to_gain=-120.0, end=float('inf'), duration=5000)
 ```
 
 **Supported keyword arguments**:

--- a/AUTHORS
+++ b/AUTHORS
@@ -66,3 +66,6 @@ Marcio Mazza
 
 Sungsu Lim
     github: proflim
+
+Xuyuan Chen
+    github: crouchred

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -1010,6 +1010,8 @@ class AudioSegment(object):
             elif end is not None:
                 start = end - duration
         else:
+            start = 0 if start is None else start
+            end = len(self) if end is None else end
             duration = end - start
 
         from_power = db_to_float(from_gain)


### PR DESCRIPTION
In AudioSegment.fade
Since the 'start' and 'end' params default to be the beginning and the end of this segment, It should still work even none of [start, end, duration] is set.
But It will confusing if only duration is set, so throw an error.
What 's more, it's a little confusing about the fade_out_the_hard_way if end=0 in API.markdown