### PR TITLE
Add linting to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ python:
   - "pypy2.7-5.8.0"
 script:
   - python test/test.py
+after_script:
+  - pip install pylama && python -m pylama -i W,E501 pydub/ || true


### PR DESCRIPTION
For visibility only, lint the code base in a non-breaking way after tests run.