### PR TITLE
[WIP] Resolve resource warnings for unclosed files

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -435,92 +435,92 @@ class AudioSegment(object):
     @classmethod
     def from_file(cls, file, format=None, codec=None, parameters=None, **kwargs):
         orig_file = file
-        file = _fd_or_path_or_tempfile(file, 'rb', tempfile=False)
+        with _fd_or_path_or_tempfile(file, 'rb', tempfile=False) as file:
 
-        if format:
-            format = format.lower()
-            format = AUDIO_FILE_EXT_ALIASES.get(format, format)
+            if format:
+                format = format.lower()
+                format = AUDIO_FILE_EXT_ALIASES.get(format, format)
 
-        def is_format(f):
-            f = f.lower()
-            if format == f:
-                return True
-            if isinstance(orig_file, basestring):
-                return orig_file.lower().endswith(".{0}".format(f))
-            return False
+            def is_format(f):
+                f = f.lower()
+                if format == f:
+                    return True
+                if isinstance(orig_file, basestring):
+                    return orig_file.lower().endswith(".{0}".format(f))
+                return False
 
-        if is_format("wav"):
+            if is_format("wav"):
+                try:
+                    return cls._from_safe_wav(file)
+                except:
+                    file.seek(0)
+            elif is_format("raw") or is_format("pcm"):
+                sample_width = kwargs['sample_width']
+                frame_rate = kwargs['frame_rate']
+                channels = kwargs['channels']
+                metadata = {
+                    'sample_width': sample_width,
+                    'frame_rate': frame_rate,
+                    'channels': channels,
+                    'frame_width': channels * sample_width
+                }
+                return cls(data=file.read(), metadata=metadata)
+
+            input_file = NamedTemporaryFile(mode='wb', delete=False)
             try:
-                return cls._from_safe_wav(file)
-            except:
-                file.seek(0)
-        elif is_format("raw") or is_format("pcm"):
-            sample_width = kwargs['sample_width']
-            frame_rate = kwargs['frame_rate']
-            channels = kwargs['channels']
-            metadata = {
-                'sample_width': sample_width,
-                'frame_rate': frame_rate,
-                'channels': channels,
-                'frame_width': channels * sample_width
-            }
-            return cls(data=file.read(), metadata=metadata)
-
-        input_file = NamedTemporaryFile(mode='wb', delete=False)
-        try:
-            input_file.write(file.read())
-        except(OSError):
-            input_file.flush()
-            input_file.close()
-            input_file = NamedTemporaryFile(mode='wb', delete=False, buffering=2**31-1)
-            file = open(orig_file, buffering=2**13-1, mode='rb')
-            reader = file.read(2**31-1)
-            while reader:
-                input_file.write(reader)
+                input_file.write(file.read())
+            except(OSError):
+                input_file.flush()
+                input_file.close()
+                input_file = NamedTemporaryFile(mode='wb', delete=False, buffering=2**31-1)
+                file = open(orig_file, buffering=2**13-1, mode='rb')
                 reader = file.read(2**31-1)
-        input_file.flush()
+                while reader:
+                    input_file.write(reader)
+                    reader = file.read(2**31-1)
+            input_file.flush()
 
-        output = NamedTemporaryFile(mode="rb", delete=False)
+            output = NamedTemporaryFile(mode="rb", delete=False)
 
-        conversion_command = [cls.converter,
-                              '-y',  # always overwrite existing files
-                              ]
+            conversion_command = [cls.converter,
+                                  '-y',  # always overwrite existing files
+                                  ]
 
-        # If format is not defined
-        # ffmpeg/avconv will detect it automatically
-        if format:
-            conversion_command += ["-f", format]
+            # If format is not defined
+            # ffmpeg/avconv will detect it automatically
+            if format:
+                conversion_command += ["-f", format]
 
-        if codec:
-            # force audio decoder
-            conversion_command += ["-acodec", codec]
+            if codec:
+                # force audio decoder
+                conversion_command += ["-acodec", codec]
 
-        conversion_command += [
-            "-i", input_file.name,  # input_file options (filename last)
-            "-vn",  # Drop any video streams if there are any
-            "-f", "wav",  # output options (filename last)
-            output.name
-        ]
+            conversion_command += [
+                "-i", input_file.name,  # input_file options (filename last)
+                "-vn",  # Drop any video streams if there are any
+                "-f", "wav",  # output options (filename last)
+                output.name
+            ]
 
-        if parameters is not None:
-            # extend arguments with arbitrary set
-            conversion_command.extend(parameters)
+            if parameters is not None:
+                # extend arguments with arbitrary set
+                conversion_command.extend(parameters)
 
-        log_conversion(conversion_command)
+            log_conversion(conversion_command)
 
-        p = subprocess.Popen(conversion_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        p_out, p_err = p.communicate()
+            p = subprocess.Popen(conversion_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p_out, p_err = p.communicate()
 
-        if p.returncode != 0:
-            raise CouldntDecodeError("Decoding failed. ffmpeg returned error code: {0}\n\nOutput from ffmpeg/avlib:\n\n{1}".format(p.returncode, p_err))
+            if p.returncode != 0:
+                raise CouldntDecodeError("Decoding failed. ffmpeg returned error code: {0}\n\nOutput from ffmpeg/avlib:\n\n{1}".format(p.returncode, p_err))
 
-        try:
-            obj = cls._from_safe_wav(output)
-        finally:
-            input_file.close()
-            output.close()
-            os.unlink(input_file.name)
-            os.unlink(output.name)
+            try:
+                obj = cls._from_safe_wav(output)
+            finally:
+                input_file.close()
+                output.close()
+                os.unlink(input_file.name)
+                os.unlink(output.name)
 
         return obj
 


### PR DESCRIPTION
A work-in-progress PR for #214. 

As suggested by @augustoccesar I've added `with` to the`from_file` method. And now I see no warnings for:

```
python3 -W default -c 'import pydub; pydub.AudioSegment.from_file("./test/data/test1.mp3")'
# no warnings
```

Looking at other uses of `_fd_or_path_or_tempfile `, the `_from_safe_wav` method no longer has issues either:

```
python3 -W default -c 'import pydub; pydub.AudioSegment.from_file("./test/data/test1.wav")'
# no warnings
```