### PR TITLE
Don't give subprocess our stdin, give it os.devnull instead.

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -508,7 +508,8 @@ class AudioSegment(object):
 
         log_conversion(conversion_command)
 
-        p = subprocess.Popen(conversion_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        with open(os.devnull, 'rb') as devnull:
+            p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p_out, p_err = p.communicate()
 
         log_subprocess_output(p_out)
@@ -674,7 +675,8 @@ class AudioSegment(object):
         log_conversion(conversion_command)
 
         # read stdin / write stdout
-        p = subprocess.Popen(conversion_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        with open(os.devnull, 'rb') as devnull:
+            p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p_out, p_err = p.communicate()
 
         log_subprocess_output(p_out)


### PR DESCRIPTION
When calling subprocess.Popen to call ffmpeg, the process inherits our standard input. Apparently ffmpeg modifies the terminal parameters if it is given a TTY on standard in. Usually this isn't a problem, because ffmpeg sets them back to what they were when it is done. However if you're calling `AudioSegment.from_file()` or `AudioSegment.export()` from multiple threads at once, the multiple ffmpeg process race each other in setting/getting the shared terminal parameters.

On my machine at least, this pretty consistently leaves my terminal hosed when my program exits -- turning off echoing, and other weirdness, which is only fixed by blindly typing `reset` into the terminal.

The easy solution seems to be to just give ffmpeg/avconv a file descriptor to `os.devnull` on stdin, which fixes the problem for me. Tested with ffmpeg, not with avconv, but I would be surprised if it broke anything.