### PR TITLE
Change detect_silence thresholding from < to <=

### DIFF
--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -28,7 +28,7 @@ def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, seek
 
     for i in slice_starts:
         audio_slice = audio_segment[i:i + min_silence_len]
-        if audio_slice.rms < silence_thresh:
+        if audio_slice.rms <= silence_thresh:
             silence_starts.append(i)
 
     # short circuit when there is no silence


### PR DESCRIPTION
Changed silence thresholding from < to <=.
With < there is no way to threshold for absolute silence (-inf dB).
Because amplitudes are floats, side effects of the change should be negligible.