### PR TITLE
When converting stereo to mono, divide samples by two to avoid clipping

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -752,11 +752,13 @@ class AudioSegment(object):
         if channels == 2 and self.channels == 1:
             fn = audioop.tostereo
             frame_width = self.frame_width * 2
+            fac = 1
         elif channels == 1 and self.channels == 2:
             fn = audioop.tomono
             frame_width = self.frame_width // 2
+            fac = 0.5
 
-        converted = fn(self._data, self.sample_width, 1, 1)
+        converted = fn(self._data, self.sample_width, fac, fac)
 
         return self._spawn(data=converted,
                            overrides={


### PR DESCRIPTION
The correct way to convert stereo to mono is to take the average of the two samples, because a full-power sample L and R added together will be 2x full power which will clip horribly.  I confirmed this by trying to convert normalized files from stereo to mono.  Setting the gain factor to 0.5 is equivalent to (L + R) / 2 and fixes the issue.