### PR TITLE
AudioSegment.from_file not erasing tmp files on failure - fix

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -515,10 +515,9 @@ class AudioSegment(object):
         log_subprocess_output(p_out)
         log_subprocess_output(p_err)
 
-        if p.returncode != 0:
-            raise CouldntDecodeError("Decoding failed. ffmpeg returned error code: {0}\n\nOutput from ffmpeg/avlib:\n\n{1}".format(p.returncode, p_err))
-
         try:
+            if p.returncode != 0:
+                raise CouldntDecodeError("Decoding failed. ffmpeg returned error code: {0}\n\nOutput from ffmpeg/avlib:\n\n{1}".format(p.returncode, p_err))
             obj = cls._from_safe_wav(output)
         finally:
             input_file.close()

--- a/test/test.py
+++ b/test/test.py
@@ -863,7 +863,7 @@ class AudioSegmentTests(unittest.TestCase):
             tmp_wav_file.flush()
             self.assertRaises(CouldntDecodeError, AudioSegment.from_file, tmp_wav_file.name)
             files = os.listdir(tempfile.tempdir)
-            self.assertListEqual(files, [os.path.basename(tmp_wav_file.name)])
+            self.assertEquals(files, [os.path.basename(tmp_wav_file.name)])
 
         if sys.platform == 'win32':
             os.remove(tmp_wav_file.name)

--- a/test/test.py
+++ b/test/test.py
@@ -866,7 +866,7 @@ class AudioSegmentTests(unittest.TestCase):
             self.assertListEqual(files, [os.path.basename(tmp_wav_file.name)])
 
         if sys.platform == 'win32':
-            os.remove(tmp_mp3_file.name)
+            os.remove(tmp_wav_file.name)
 
         tempfile.tempdir = orig_tmpdir
         os.rmdir(new_tmpdir)

--- a/test/test.py
+++ b/test/test.py
@@ -859,7 +859,7 @@ class AudioSegmentTests(unittest.TestCase):
         tempfile.tempdir = new_tmpdir
 
         with NamedTemporaryFile('w+b', suffix='.wav', delete=delete) as tmp_wav_file:
-            tmp_wav_file.write("not really a wav")
+            tmp_wav_file.write("not really a wav".encode('utf-8'))
             tmp_wav_file.flush()
             self.assertRaises(CouldntDecodeError, AudioSegment.from_file, tmp_wav_file.name)
             files = os.listdir(tempfile.tempdir)


### PR DESCRIPTION
### Steps to reproduce
- Create an invalid sound file, for example: `echo "invalid wav content" > wrong.wav`
- Try to instantiate an AudioSegment using from_file method passing `wrong.wav`

### Expected behavior
- Should fail with appropiate message and remove the intermediary tmp files created for conversions/imports.

### Actual behavior
Fails the import with a nice message but leaves the tmp files on the tmp directory. New tmp files are created with the same size as the files being loaded, plus and extra file with size 0 for each corrupted file. Thats a problem on long running processes or in case we're dealing with large corrupted files or large collection of medium size corrupted audio files. 

### Your System configuration
- Python version: 2.7.12
- Pydub version: master HEAD (c95b814e1e974eb84f4af8f8062d7a09ef29ef1d)
- ffmpeg or avlib: ffmpeg
- ffmpeg/avlib version: 3.2

### Is there an audio file you can include to help us reproduce?
Easily created by `echo "invalid wav content" > wrong.wav`. There's a test in the PR.