### PR TITLE
ffmpeg ffplay deprecated in favor of sdl2

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -197,7 +197,7 @@ brew install libav --with-libvorbis --with-sdl --with-theora
 ####    OR    #####
 
 # ffmpeg
-brew install ffmpeg --with-libvorbis --with-ffplay --with-theora
+brew install ffmpeg --with-libvorbis --with-sdl2 --with-theora
 ```
 
 Linux (using aptitude):


### PR DESCRIPTION
Noticed a warning when installing ffmpeg with homebrew. It said `ffplay` is deprecated and is using `sdl2` instead so I am suggesting to simply change that.