### PR TITLE
Introduce a base exception class

### DIFF
--- a/pydub/exceptions.py
+++ b/pydub/exceptions.py
@@ -1,26 +1,30 @@
+class PydubException(Exception):
+    """
+    Base class for any Pydub exception
+    """
 
 
-class TooManyMissingFrames(Exception):
+class TooManyMissingFrames(PydubException):
     pass
 
 
-class InvalidDuration(Exception):
+class InvalidDuration(PydubException):
     pass
 
 
-class InvalidTag(Exception):
+class InvalidTag(PydubException):
     pass
 
 
-class InvalidID3TagVersion(Exception):
+class InvalidID3TagVersion(PydubException):
     pass
 
 
-class CouldntDecodeError(Exception):
-    pass
-    
-class CouldntEncodeError(Exception):
+class CouldntDecodeError(PydubException):
     pass
 
-class MissingAudioParameter(Exception):
+class CouldntEncodeError(PydubException):
+    pass
+
+class MissingAudioParameter(PydubException):
     pass

--- a/pydub/exceptions.py
+++ b/pydub/exceptions.py
@@ -23,8 +23,10 @@ class InvalidID3TagVersion(PydubException):
 class CouldntDecodeError(PydubException):
     pass
 
+
 class CouldntEncodeError(PydubException):
     pass
+
 
 class MissingAudioParameter(PydubException):
     pass


### PR DESCRIPTION
This introduces the `PydubException` base exception class.

It's a very small contribution but makes Pydub-related errors more consistent and a bit easier to handle:

```python
@celery_app.task(bind=True, max_retries=3)
def process_audio(self, audio_src: str) -> bytes:
    """
    Find and convert a WAV audio source into MP3
    """
    try:
        audio_bytes = retrieve_audio_file(audio_src)
        wav_audio = pydub.AudioSegment.from_wav(wav_container)
        mp3_container = io.BytesIO()
        wav_audio.export(
            mp3_container,
            codec='libmp3lame', format='mp3', parameters=['-q:a', '5'],
        )
    
    except (FileNotFoundError, PydubException,) as err:
        self.retry(exc=err)
    
    else:
        return mp3.read()
```


...And also fix some PEP8 complaints.