### PR TITLE
Adds support for PEP 519 File Path protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy2.7-5.8.0"
 script:
   - python test/test.py

--- a/API.markdown
+++ b/API.markdown
@@ -80,6 +80,11 @@ mp3_audio = AudioSegment.from_file("/path/to/sound.mp3", format="mp3")
 # use a file you've already opened (advanced …ish)
 with open("/path/to/sound.wav", "rb") as wav_file:
     audio_segment = AudioSegment.from_file(wav_file, format="wav")
+
+# also supports the os.PathLike protocol for python >= 3.6
+from pathlib import Path
+wav_path = Path("path/to/sound.wav")
+wav_audio = AudioSegment.from_file(wav_path)
 ```
 
 The first argument is the path (as a string) of the file to read, **or** a file handle to read from.

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -577,7 +577,8 @@ class AudioSegment(object):
         Export an AudioSegment to a file with given options
 
         out_f (string):
-            Path to destination audio file
+            Path to destination audio file. Also accepts os.PathLike objects on
+            python >= 3.6
 
         format (string)
             Format for destination audio file.

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -447,6 +447,25 @@ class AudioSegment(object):
                 return True
             if isinstance(orig_file, basestring):
                 return orig_file.lower().endswith(".{0}".format(f))
+            if sys.version_info >= (3, 6):
+                try:
+                    path = os.fspath(orig_file)
+
+                    if isinstance(path, bytes):
+                        try:
+                            path = path.decode(sys.getdefaultencoding())    
+                        except Exception:
+                            pass
+
+                    return path.lower().endswith(".{0}".format(f))
+                except TypeError:
+                    # Either orig_file was not a str, bytes, or PathLike
+                    # object, or os.fspath() returned a byte string and and we
+                    # failed to decode it, then endswith() tried to compare
+                    # that with a regular str. In either case, we can't discern
+                    # the file extension.
+                    pass
+
             return False
 
         if is_format("wav"):

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -448,23 +448,9 @@ class AudioSegment(object):
             if isinstance(orig_file, basestring):
                 return orig_file.lower().endswith(".{0}".format(f))
             if sys.version_info >= (3, 6):
-                try:
-                    path = os.fspath(orig_file)
-
-                    if isinstance(path, bytes):
-                        try:
-                            path = path.decode(sys.getdefaultencoding())    
-                        except Exception:
-                            pass
-
+                if isinstance(orig_file, os.PathLike):
+                    path = os.fsdecode(orig_file)
                     return path.lower().endswith(".{0}".format(f))
-                except TypeError:
-                    # Either orig_file was not a str, bytes, or PathLike
-                    # object, or os.fspath() returned a byte string and and we
-                    # failed to decode it, then endswith() tried to compare
-                    # that with a regular str. In either case, we can't discern
-                    # the file extension.
-                    pass
 
             return False
 

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -62,6 +62,8 @@ def _fd_or_path_or_tempfile(fd, mode='w+b', tempfile=True):
         if isinstance(fd, os.PathLike):
             fd = open(fd, mode=mode)
     except AttributeError:
+        # module os has no attribute PathLike, so we're on python < 3.6.
+        # The protocol we're trying to support doesn't exist, so just pass.
         pass
 
     return fd

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -58,6 +58,12 @@ def _fd_or_path_or_tempfile(fd, mode='w+b', tempfile=True):
     if isinstance(fd, basestring):
         fd = open(fd, mode=mode)
 
+    try:
+        if isinstance(fd, os.PathLike):
+            fd = open(fd, mode=mode)
+    except AttributeError:
+        pass
+
     return fd
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -77,7 +77,7 @@ if sys.version_info >= (3, 6):
             seg2 = AudioSegment.from_file(self.mp3_pathlib_path)
 
             self.assertEqual(len(seg1), len(seg2))
-            self.assertTrue(seg1._data == seg2._data)
+            self.assertEqual(seg1._data, seg2._data)
             self.assertTrue(len(seg1) > 0)
 
         def test_audio_segment_from_path_like_str(self):
@@ -85,7 +85,7 @@ if sys.version_info >= (3, 6):
             seg2 = AudioSegment.from_file(self.mp3_path_like_str)
 
             self.assertEqual(len(seg1), len(seg2))
-            self.assertTrue(seg1._data == seg2._data)
+            self.assertEqual(seg1._data, seg2._data)
             self.assertTrue(len(seg1) > 0)
 
         def test_audio_segment_from_path_like_bytes(self):
@@ -93,7 +93,7 @@ if sys.version_info >= (3, 6):
             seg2 = AudioSegment.from_file(self.mp3_path_like_bytes)
 
             self.assertEqual(len(seg1), len(seg2))
-            self.assertTrue(seg1._data == seg2._data)
+            self.assertEqual(seg1._data, seg2._data)
             self.assertTrue(len(seg1) > 0)
 
         def test_non_existant_pathlib_path(self):

--- a/test/test.py
+++ b/test/test.py
@@ -162,6 +162,7 @@ class FileAccessTests(unittest.TestCase):
 
     def setUp(self):
         self.mp3_path = os.path.join(data_dir, 'test1.mp3')
+
     def test_audio_segment_from_mp3(self):
         seg1 = AudioSegment.from_mp3(os.path.join(data_dir, 'test1.mp3'))
 
@@ -171,7 +172,6 @@ class FileAccessTests(unittest.TestCase):
         self.assertEqual(len(seg1), len(seg2))
         self.assertTrue(seg1._data == seg2._data)
         self.assertTrue(len(seg1) > 0)
-
 
 
 test1wav = test4wav = test1 = test2 = test3 = testparty = testdcoffset = None

--- a/test/test.py
+++ b/test/test.py
@@ -103,9 +103,11 @@ if sys.version_info >= (3, 6):
                 _ = AudioSegment.from_file(path)
 
             path = Path('')
-            # Passing an empty string to pathlib.Path results in the path to
-            # the current directory.
-            with self.assertRaises(IsADirectoryError):
+            # On Unicies this will raise a IsADirectoryError, on Windows this
+            # will result in a PermissionError. Both of these are subclasses of
+            # OSError. We aren't so much worried about the specific exception
+            # here, just that reading a file from an empty path is an error.
+            with self.assertRaises(OSError):
                 _ = AudioSegment.from_file(path)
 
         def test_non_existant_path_like_str(self):

--- a/test/test.py
+++ b/test/test.py
@@ -70,6 +70,31 @@ class FileAccessTests(unittest.TestCase):
         self.assertTrue(seg1._data == seg2._data)
         self.assertTrue(len(seg1) > 0)
 
+    def test_audio_segment_from_path_like_object(self):
+        try:
+            # The import of fspath() is unusd, but is what will actually raise
+            # the ImportError. os.fspath() was introduced in python 3.6, while
+            # pathlib came in 3.4. While we could call str() to get a string
+            # representation of pathlib objects when they're passed to
+            # AudioSegment.from_file(), giving support to 3.4 and 3.5, it is
+            # safe to assume that users of 3.4 or 3.5 that use Path objects are
+            # aware of the limitations, and are used to calling str()
+            # themselves.
+            from os import fspath
+            from pathlib import Path
+
+            mp3_path_obj = Path(self.mp3_path)
+
+            seg1 = AudioSegment.from_file(self.mp3_path)
+            seg2 = AudioSegment.from_file(mp3_path_obj)
+
+            self.assertEqual(len(seg1), len(seg2))
+            self.assertTrue(seg1._data == seg2._data)
+            self.assertTrue(len(seg1) > 0)
+        except ImportError:
+            # We're on python < 3.6, so there's nothing to test.
+            pass
+
 
 test1wav = test4wav = test1 = test2 = test3 = testparty = testdcoffset = None
 

--- a/test/test.py
+++ b/test/test.py
@@ -149,7 +149,6 @@ if sys.version_info >= (3, 6):
                 seg1.export(path, format='mp3')
                 seg2 = AudioSegment.from_file(path, format='mp3')
 
-                self.assertEqual(len(seg1), len(seg2))
                 self.assertTrue(len(seg1) > 0)
                 self.assertWithinTolerance(len(seg1),
                                            len(seg2),

--- a/test/test.py
+++ b/test/test.py
@@ -126,6 +126,35 @@ if sys.version_info >= (3, 6):
             with self.assertRaises(FileNotFoundError):
                 _ = AudioSegment.from_file(path)
 
+        def assertWithinRange(self, val, lower_bound, upper_bound):
+            self.assertTrue(lower_bound < val < upper_bound,
+                            "%s is not in the acceptable range: %s - %s" %
+                            (val, lower_bound, upper_bound))
+
+        def assertWithinTolerance(self, val, expected, tolerance=None,
+                                percentage=None):
+            if percentage is not None:
+                tolerance = val * percentage
+            lower_bound = val - tolerance
+            upper_bound = val + tolerance
+            self.assertWithinRange(val, lower_bound, upper_bound)
+
+        def test_export_pathlib_path(self):
+            seg1 = AudioSegment.from_file(self.mp3_path_str)
+            from pathlib import Path
+            path = Path(tempfile.gettempdir()) / 'pydub-test-export-8ajds.mp3'
+            try:
+                seg1.export(path, format='mp3')
+                seg2 = AudioSegment.from_file(path, format='mp3')
+
+                self.assertEqual(len(seg1), len(seg2))
+                self.assertTrue(len(seg1) > 0)
+                self.assertWithinTolerance(len(seg1),
+                                           len(seg2),
+                                           percentage=0.01)
+            finally:
+                os.unlink(path)
+        
 
 class FileAccessTests(unittest.TestCase):
 


### PR DESCRIPTION
Allows `AudioSegment.from_file()` and `AudioSegment.export()` to accept [PathLike](https://docs.python.org/3/whatsnew/3.6.html#whatsnew36-pep519) objects that represent file system paths, in addition to strings.

Python 3.4 introduced [pathlib](https://docs.python.org/3/library/pathlib.html) to make handling filesystem paths easier. In Python 3.6, [PEP 519](https://www.python.org/dev/peps/pep-0519/) added support for a new protocol to many builtin methods, such as `open`, to allow objects to signal that they represent filesystem paths by returning a `str` or `bytes` from a `__fspath()__` method.


```python
>>> from pydub import AudioSegment
>>> from pathlib import Path
>>> music_folder = Path('music')
>>> song_path = music_folder / 'my_song.mp3'
>>> song_audio = AudioSegment.from_file(song_path)
>>> song_audio.export(music_folder / 'my_song_backup.mp3')
```

Explicit support for the protocol is necessary since the utility method `_fd_or_path_or_tempfile` is expected to return anything that isn't a string that represents a path unaltered, and thus explicitly checks for string. 