### PR TITLE
Fix hls branch

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,3 +69,6 @@ Sungsu Lim
 
 Evandro Myller
     github: emyller
+
+Dylan
+    github: dotingsprites

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -690,7 +690,13 @@ class AudioSegment(object):
         if p.returncode != 0:
             raise CouldntEncodeError("Encoding failed. ffmpeg/avlib returned error code: {0}\n\nCommand:{1}\n\nOutput from ffmpeg/avlib:\n\n{2}".format(p.returncode, conversion_command, p_err))
 
-        output.seek(0)
+        # for some reason, a HLS m3u8 file will be empty unless reopened in read-only mode
+        if format == 'hls':
+            output.close()
+            output = open(output.name, 'rb')
+        else:
+            output.seek(0)
+
         out_f.write(output.read())
 
         data.close()

--- a/test/test.py
+++ b/test/test.py
@@ -559,7 +559,6 @@ class AudioSegmentTests(unittest.TestCase):
         ]
         out_m3u8 = seg.export(
             format = "hls",
-            codec = "libfaac",
             parameters = ffmpeg_opts
         )
 

--- a/test/test.py
+++ b/test/test.py
@@ -549,11 +549,8 @@ class AudioSegmentTests(unittest.TestCase):
 
     def test_export_as_hls(self):
         seg = self.seg1
-        import random
-        segment_filename = str(int(random.random() * 1000))
         ffmpeg_opts = [
             "-hls_list_size", "0",
-            "-hls_segment_filename", os.path.join(data_dir, segment_filename + "%d.ts"),
             "-hls_time", "10",
             "-start_number", "0"
         ]
@@ -567,15 +564,15 @@ class AudioSegmentTests(unittest.TestCase):
 
         # check that all segments match up in length to original
         import glob
-        segment_files = glob.glob(os.path.join(data_dir, segment_filename + '*.ts'))
+        segment_files = glob.glob(os.path.join(gettempdir(), '*.ts'))
         exported_audio_length = sum(len(AudioSegment.from_file(segment, format = "mpegts")) for segment in segment_files)
         self.assertWithinTolerance(exported_audio_length,
                                    len(seg),
                                    percentage = 0.01)
 
         # cleanup segment files
-        for segment in glob.glob(os.path.join(data_dir, '*.ts')):
-		    os.remove(segment)
+        for segment in glob.glob(os.path.join(gettempdir(), '*.ts')):
+            os.remove(segment)
 
     def test_export_forced_codec(self):
         seg = self.seg1 + self.seg2


### PR DESCRIPTION
I'm using this library to generate HLS audio streams. I ran into a problem where, after encoding the stream, the m3u8 playlist file would be empty. I looked at the ``AudioSegment.export()`` function, and for some reason, closing and re-opening the temporary output file as read-only gets the playlist file from ffmpeg fine. Don't know why the file needs to be closed and re-opened and would be interested to see if anyone knows, but for now, the work-around I created seems to work fine.