### PR TITLE
Include licence file in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(
     url='http://pydub.com',
     packages=['pydub'],
     long_description=__doc__,
+    package_data={
+        '': ['LICENSE'],
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Adds the `LICENSE` file as a data file for any packages listed in `setup.py`.

Fixes #274