### PR TITLE
Fix python 2 hashing incompatibility

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,3 +75,6 @@ Sérgio Agostinho
 
 Antonio Larrosa
     github: antlarr
+
+Aaron Craig
+    github: craigthelinguist

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -279,8 +279,8 @@ class AudioSegment(object):
         except:
             return False
 
-    # Disables hashing of AudioSegment objects in a python2-compatible manner.
-    __hash__ = None
+    def __hash__(self):
+       return hash(AudioSegment) ^ hash((self.channels, self.frame_rate, self.sample_width, self._data))
 
     def __ne__(self, other):
         return not (self == other)

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -279,6 +279,9 @@ class AudioSegment(object):
         except:
             return False
 
+    # Disables hashing of AudioSegment objects in a python2-compatible manner.
+    __hash__ = None
+
     def __ne__(self, other):
         return not (self == other)
 


### PR DESCRIPTION
Fixes #295 

Sets the `__hash__` attribute of `AudioSegment` to `None`, preventing someone from accidentally hashing it and ensuring consistent behaviour across python 2 and python 3.