### PR TITLE
write_xing options seems to be only available for mp3 convertion

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -848,7 +848,7 @@ class AudioSegment(object):
                         "-id3v2_version", id3v2_version
                     ])
 
-        if sys.platform == 'darwin':
+        if sys.platform == 'darwin' and codec == 'mp3':
             conversion_command.extend(["-write_xing", "0"])
 
         conversion_command.extend([


### PR DESCRIPTION
This should resove #269 
In some documentation I found, the write_xing option seems to be only available on mp3.
https://manpages.debian.org/jessie/libav-tools/avconv.1.en.html

I tested manually the avconv command with the write_xing parameter, it seems to work well.