### PR TITLE
Update README to update libavcodec-extra version

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -204,12 +204,12 @@ Linux (using aptitude):
 
 ```bash
 # libav
-apt-get install libav-tools libavcodec-extra-53
+apt-get install libav-tools libavcodec-extra
 
 ####    OR    #####
 
 # ffmpeg
-apt-get install ffmpeg libavcodec-extra-53
+apt-get install ffmpeg libavcodec-extra
 ```
 
 Windows:


### PR DESCRIPTION
The libavcodec-extra-53 is not available anymore on the oficial aptitude repositories.

The [libavcodec-extra](https://packages.debian.org/jessie/libavcodec-extra) works properly and is officially supported.