### PR TITLE
fix issue #308: now uses right acodec for 8bit audio

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -672,7 +672,11 @@ class AudioSegment(object):
                 bits_per_sample = 16
             else:
                 bits_per_sample = audio_streams[0]['bits_per_sample']
-            acodec = 'pcm_s%dle' % bits_per_sample
+            if bits_per_sample == 8:
+                acodec = 'pcm_s8'
+            else:
+                acodec = 'pcm_s%dle' % bits_per_sample
+
             conversion_command += ["-acodec", acodec]
 
         conversion_command += [


### PR DESCRIPTION
Fix an issue with FFMPEG acodec. When dealing with 8 bit audio, the right format is **'pcm_s8'**, not **'pcm_s8le'**.