### PR TITLE
Fix parameter passing for file decoding

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -713,19 +713,19 @@ class AudioSegment(object):
 
     @classmethod
     def from_mp3(cls, file, parameters=None):
-        return cls.from_file(file, 'mp3', parameters)
+        return cls.from_file(file, 'mp3', parameters=parameters)
 
     @classmethod
     def from_flv(cls, file, parameters=None):
-        return cls.from_file(file, 'flv', parameters)
+        return cls.from_file(file, 'flv', parameters=parameters)
 
     @classmethod
     def from_ogg(cls, file, parameters=None):
-        return cls.from_file(file, 'ogg', parameters)
+        return cls.from_file(file, 'ogg', parameters=parameters)
 
     @classmethod
     def from_wav(cls, file, parameters=None):
-        return cls.from_file(file, 'wav', parameters)
+        return cls.from_file(file, 'wav', parameters=parameters)
 
     @classmethod
     def from_raw(cls, file, **kwargs):


### PR DESCRIPTION
The old function 
```
    @classmethod
    def from_mp3(cls, file, parameters=None):
        return cls.from_file(file, 'mp3', parameters)
```
turns around and makes a call with parameters being the 3rd argument to the function with signature 

`def from_file(cls, file, format=None, codec=None, parameters=None, **kwargs):`

the end result call is `from_file(file=file, format='mp3', codec=parameters)`
`codec=parameters` is a pretty tricky hidden pattern and not what I think was intended.

