### PR TITLE
Define buffer = bytes in Python 3

### DIFF
--- a/pydub/pyaudioop.py
+++ b/pydub/pyaudioop.py
@@ -4,6 +4,10 @@ try:
 except ImportError:
     from builtins import max as builtin_max
     from builtins import min as builtin_min
+try:
+    buffer
+except NameError:
+    buffer = bytes
 import math
 import struct
 from fractions import gcd


### PR DESCRIPTION
__buffer__ was removed in Python 3 in favor of __memoryview__.