### PR TITLE
Travis CI: Add Python 3.7 and remove Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-dist: trusty
 language: python
 env:
   - CONVERTER=ffmpeg
@@ -11,11 +9,13 @@ install:
   - sudo apt-get install -y ${CONVERTER} libopus-dev python-scipy python3-scipy
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "pypy2.7-5.8.0"
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 script:
   - python test/test.py
 after_script:


### PR DESCRIPTION
Python 3.4 reaches its end of life in 40 days: https://devguide.python.org/#branchstatus

 [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).