### PR TITLE
Skip tests that use unavailable codecs

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -18,6 +18,8 @@ from pydub.utils import (
     make_chunks,
     mediainfo,
     get_encoder_name,
+    get_supported_decoders,
+    get_supported_encoders,
 )
 from pydub.exceptions import (
     InvalidTag,
@@ -670,6 +672,8 @@ class AudioSegmentTests(unittest.TestCase):
             if sys.platform == 'win32':
                 os.remove(tmp_mp3_file.name)
 
+    @unittest.skipUnless('aac' in get_supported_decoders(),
+                         "Unsupported codecs")
     def test_formats(self):
         seg_m4a = AudioSegment.from_file(
             os.path.join(data_dir, 'format_test.m4a'), "m4a")
@@ -688,6 +692,8 @@ class AudioSegmentTests(unittest.TestCase):
         wav = AudioSegment.from_wav(wav_file)
         self.assertEqual(wav.duration_seconds, self.seg1.duration_seconds)
 
+    @unittest.skipUnless('aac' in get_supported_decoders(),
+                         "Unsupported codecs")
     def test_autodetect_format(self):
         aac_path = os.path.join(data_dir, 'wrong_extension.aac')
         fn = partial(AudioSegment.from_file, aac_path, "aac")
@@ -720,21 +726,29 @@ class AudioSegmentTests(unittest.TestCase):
             AudioSegment.from_file(self.mp3_file_path).export(tmp_webm_file,
                                                               format="webm")
 
+    @unittest.skipUnless('aac' in get_supported_decoders(),
+                         "Unsupported codecs")
     def test_export_mp4_as_ogg(self):
         with NamedTemporaryFile('w+b', suffix='.ogg') as tmp_ogg_file:
             AudioSegment.from_file(self.mp4_file_path).export(tmp_ogg_file,
                                                               format="ogg")
 
+    @unittest.skipUnless('aac' in get_supported_decoders(),
+                         "Unsupported codecs")
     def test_export_mp4_as_mp3(self):
         with NamedTemporaryFile('w+b', suffix='.mp3') as tmp_mp3_file:
             AudioSegment.from_file(self.mp4_file_path).export(tmp_mp3_file,
                                                               format="mp3")
 
+    @unittest.skipUnless('aac' in get_supported_decoders(),
+                         "Unsupported codecs")
     def test_export_mp4_as_wav(self):
         with NamedTemporaryFile('w+b', suffix='.wav') as tmp_wav_file:
             AudioSegment.from_file(self.mp4_file_path).export(tmp_wav_file,
                                                               format="mp3")
 
+    @unittest.skipUnless('aac' in get_supported_decoders(),
+                         "Unsupported codecs")
     def test_export_mp4_as_mp3_with_tags(self):
         with NamedTemporaryFile('w+b', suffix='.mp3') as tmp_mp3_file:
             tags_dict = {
@@ -746,6 +760,8 @@ class AudioSegmentTests(unittest.TestCase):
                                                               format="mp3",
                                                               tags=tags_dict)
 
+    @unittest.skipUnless('aac' in get_supported_decoders(),
+                         "Unsupported codecs")
     def test_export_mp4_as_mp3_with_tags_raises_exception_when_tags_are_not_a_dictionary(self):
         with NamedTemporaryFile('w+b', suffix='.mp3') as tmp_mp3_file:
             json = '{"title": "The Title You Want", "album": "Name of the Album", "artist": "Artist\'s name"}'
@@ -754,6 +770,8 @@ class AudioSegmentTests(unittest.TestCase):
                 format="mp3", tags=json)
             self.assertRaises(InvalidTag, func)
 
+    @unittest.skipUnless('aac' in get_supported_decoders(),
+                         "Unsupported codecs")
     def test_export_mp4_as_mp3_with_tags_raises_exception_when_id3version_is_wrong(self):
         tags = {'artist': 'Artist', 'title': 'Title'}
         with NamedTemporaryFile('w+b', suffix='.mp3') as tmp_mp3_file:
@@ -766,6 +784,8 @@ class AudioSegmentTests(unittest.TestCase):
             )
             self.assertRaises(InvalidID3TagVersion, func)
 
+    @unittest.skipUnless('aac' in get_supported_decoders(),
+                         "Unsupported codecs")
     def test_export_mp3_with_tags(self):
         tags = {'artist': 'Mozart', 'title': 'The Magic Flute'}
 
@@ -883,6 +903,8 @@ class AudioSegmentTests(unittest.TestCase):
         # average volume should be reduced
         self.assertTrue(compressed.rms < self.seg1.rms)
 
+    @unittest.skipUnless('aac' in get_supported_decoders(),
+                         "Unsupported codecs")
     def test_exporting_to_ogg_uses_default_codec_when_codec_param_is_none(self):
         delete = sys.platform != 'win32'
 


### PR DESCRIPTION
In openSUSE, the official ffmpeg package doesn't support aac audio and some other codecs due
to legal reasons. There are ffmpeg packages available that support all codecs, but when building the official pydub packages, the official ffmpeg package is used, and so, when running tests, some of these fail because the files format_test.m4a, creative_common.mp4 and wrong_extension.aac can't be read since they use aac audio.

This commit adds two functions get_supported_decoders and get_supported_encoders that return a set with the decoders/encoders that are supported. Then it also adds some decorators to some tests to skip the tests that use unsupported codecs.

Note that functools.lru_cache was added in python 3.3, so it can't be used and that's the reason I added a small implementation of a cache decorator so we don't have to execute ffmpeg for every call to get the supported codecs.