### PR TITLE
Fix several issues related to reading from filelike objects

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -664,8 +664,11 @@ class AudioSegment(object):
             stdin_parameter = None
             stdin_data = None
         else:
-            conversion_command += ["-read_ahead_limit", str(read_ahead_limit),
-                                   "-i", "cache:pipe:0"]
+            if cls.converter == 'ffmpeg':
+                conversion_command += ["-read_ahead_limit", str(read_ahead_limit),
+                                       "-i", "cache:pipe:0"]
+            else:
+                conversion_command += ["-i", "-"]
             stdin_parameter = subprocess.PIPE
             stdin_data = file.read()
 

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -670,9 +670,9 @@ class AudioSegment(object):
                              if x['codec_type'] == 'audio']
             # This is a workaround for some ffprobe versions that always say
             # that mp3/mp4/aac/webm/ogg files contain fltp samples
+            audio_codec = audio_streams[0].get('codec_name')
             if (audio_streams[0].get('sample_fmt') == 'fltp' and
-                    (is_format("mp3") or is_format("mp4") or is_format("aac") or
-                     is_format("webm") or is_format("ogg"))):
+                    audio_codec in ['mp3', 'mp4', 'aac', 'webm', 'ogg']):
                 bits_per_sample = 16
             else:
                 bits_per_sample = audio_streams[0]['bits_per_sample']

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -282,7 +282,7 @@ class AudioSegment(object):
             return False
 
     def __hash__(self):
-       return hash(AudioSegment) ^ hash((self.channels, self.frame_rate, self.sample_width, self._data))
+        return hash(AudioSegment) ^ hash((self.channels, self.frame_rate, self.sample_width, self._data))
 
     def __ne__(self, other):
         return not (self == other)

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -653,16 +653,18 @@ class AudioSegment(object):
             # force audio decoder
             conversion_command += ["-acodec", codec]
 
+        read_ahead_limit = kwargs.get('read_ahead_limit', -1)
         if filename:
             conversion_command += ["-i", filename]
             stdin_parameter = None
             stdin_data = None
         else:
-            conversion_command += ["-i", "-"]
+            conversion_command += ["-read_ahead_limit", str(read_ahead_limit),
+                                   "-i", "cache:pipe:0"]
             stdin_parameter = subprocess.PIPE
             stdin_data = file.read()
 
-        info = mediainfo_json(orig_file)
+        info = mediainfo_json(orig_file, read_ahead_limit=read_ahead_limit)
         if info:
             audio_streams = [x for x in info['streams']
                              if x['codec_type'] == 'audio']

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -240,7 +240,7 @@ def get_extra_info(stderr):
     return extra_info
 
 
-def mediainfo_json(filepath):
+def mediainfo_json(filepath, read_ahead_limit=-1):
     """Return json dictionary with media info(codec, duration, size, bitrate...) from filepath
     """
     prober = get_prober_name()
@@ -254,7 +254,7 @@ def mediainfo_json(filepath):
         stdin_parameter = None
         stdin_data = None
     except TypeError:
-        command_args += ["-"]
+        command_args += ["-read_ahead_limit", str(read_ahead_limit), "cache:pipe:0"]
         stdin_parameter = PIPE
         file = _fd_or_path_or_tempfile(filepath, 'rb', tempfile=False)
         file.seek(0)

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -258,7 +258,11 @@ def mediainfo_json(filepath, read_ahead_limit=-1):
         stdin_parameter = None
         stdin_data = None
     except TypeError:
-        command_args += ["-read_ahead_limit", str(read_ahead_limit), "cache:pipe:0"]
+        if prober == 'ffprobe':
+            command_args += ["-read_ahead_limit", str(read_ahead_limit),
+                             "cache:pipe:0"]
+        else:
+            command_args += ["-"]
         stdin_parameter = PIPE
         file, close_file = _fd_or_path_or_tempfile(filepath, 'rb', tempfile=False)
         file.seek(0)


### PR DESCRIPTION
This PR fix several issues related to reading from filelike objects instead of files from disk.

I've separated the issues in different commits so they're clearer.


* Use the cache protocol and read_ahead_limit when piping data to ffmpeg

When piping the input file to ffmpeg on stdin ffmpeg can't seek on the file so it's unable to read the file in advance and has to guess some parameters. This is specially worrying on mp3 files, where it's common that reading the input from a file and piping the same file on stdin gives different wave results. To fix this, we now use the [cache protocol](https://ffmpeg.org/ffmpeg-protocols.html#cache) on stdin, so ffmpeg caches the input and also set read_ahead_limit to -1 (by default), so the cache can hold the whole file.

This might make ffmpeg use more memory (since it has to hold the whole file in memory), so read_ahead_limit can be set to something else when calling `from_file``` although of course, then the resulting wave data is not guaranteed to be 100% accurate.

The read_ahead_limit parameter [was introduced in ffmpeg 2.6](https://github.com/FFmpeg/FFmpeg/commit/8706910c4c051dbc7377a702aff11424585d4778#diff-16c26344ee376312f59c89c6a57022ed) so I think it's safe to depend on it.

* Use the codec information from ffprobe instead of file extension

The file extension might be wrong and may even not exist if the input is being read from a file-like object like a BytesIO object, so let's better use the codec information read from the file itself that
we already have just there.

* Do not close from_file input files if we didn't open them

from_file* methods allow to be passed a path to a file to read, but also a filelike object like a BytesIO object with the file contents. In that case, we shouldn't close the object, since that makes it unavailable
for the caller if it needs to be used for something else after we finish processing it.

This commit changes _fd_or_path_or_tempfile so it doesn't only return a file descriptor but also a boolean that tells the caller if the file descriptor can be closed or not.
