### PR TITLE
Allow codecs and parameters in wav and raw export

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -767,7 +767,7 @@ class AudioSegment(object):
             ('mp3', 'wav', 'raw', 'ogg' or other ffmpeg/avconv supported files)
 
         codec (string)
-            Codec used to encoding for the destination.
+            Codec used to encode the destination file.
 
         bitrate (string)
             Bitrate used when encoding destination file. (64, 92, 128, 256, 312k...)
@@ -775,7 +775,7 @@ class AudioSegment(object):
             ffmpeg documentation for details (bitrate usually shown as -b, -ba or
             -a:b).
 
-        parameters (string)
+        parameters (list of strings)
             Aditional ffmpeg/avconv parameters
 
         tags (dict)
@@ -790,6 +790,12 @@ class AudioSegment(object):
         """
         id3v2_allowed_versions = ['3', '4']
 
+        if format == "raw" and (codec is not None or parameters is not None):
+            raise AttributeError(
+                    'Can not invoke ffmpeg when export format is "raw"; '
+                    'specify an ffmpeg raw format like format="s16le" instead '
+                    'or call export(format="raw") with no codec or parameters')
+
         out_f, _ = _fd_or_path_or_tempfile(out_f, 'wb+')
         out_f.seek(0)
 
@@ -798,8 +804,10 @@ class AudioSegment(object):
             out_f.seek(0)
             return out_f
 
-        # for wav output we can just write the data directly to out_f
-        if format == "wav":
+        # wav with no ffmpeg parameters can just be written directly to out_f
+        easy_wav = format == "wav" and codec is None and parameters is None
+
+        if easy_wav:
             data = out_f
         else:
             data = NamedTemporaryFile(mode="wb", delete=False)
@@ -814,8 +822,8 @@ class AudioSegment(object):
         wave_data.writeframesraw(self._data)
         wave_data.close()
 
-        # for wav files, we're done (wav data is written directly to out_f)
-        if format == 'wav':
+        # for easy wav files, we're done (wav data is written directly to out_f)
+        if easy_wav:
             return out_f
 
         output = NamedTemporaryFile(mode="w+b", delete=False)

--- a/test/test.py
+++ b/test/test.py
@@ -560,6 +560,27 @@ class AudioSegmentTests(unittest.TestCase):
                                    len(seg),
                                    percentage=0.01)
 
+    def test_export_as_wav_with_codec(self):
+        seg = self.seg1
+        exported_wav = seg.export(format='wav', codec='pcm_s32le')
+        seg_exported_wav = AudioSegment.from_wav(exported_wav)
+
+        self.assertWithinTolerance(len(seg_exported_wav),
+                                   len(seg),
+                                   percentage=0.01)
+        self.assertEqual(seg_exported_wav.sample_width, 4)
+
+    def test_export_as_wav_with_parameters(self):
+        seg = self.seg1
+        exported_wav = seg.export(format='wav', parameters=['-ar', '16000', '-ac', '1'])
+        seg_exported_wav = AudioSegment.from_wav(exported_wav)
+
+        self.assertWithinTolerance(len(seg_exported_wav),
+                                   len(seg),
+                                   percentage=0.01)
+        self.assertEqual(seg_exported_wav.frame_rate, 16000)
+        self.assertEqual(seg_exported_wav.channels, 1)
+
     def test_export_as_raw(self):
         seg = self.seg1
         exported_raw = seg.export(format='raw')
@@ -569,6 +590,16 @@ class AudioSegmentTests(unittest.TestCase):
         self.assertWithinTolerance(len(seg_exported_raw),
                                    len(seg),
                                    percentage=0.01)
+
+    def test_export_as_raw_with_codec(self):
+        seg = self.seg1
+        with self.assertRaises(AttributeError):
+            seg.export(format='raw', codec='pcm_s32le')
+
+    def test_export_as_raw_with_parameters(self):
+        seg = self.seg1
+        with self.assertRaises(AttributeError):
+            seg.export(format='raw', parameters=['-ar', '16000', '-ac', '1'])
 
     def test_export_as_ogg(self):
         seg = self.seg1


### PR DESCRIPTION
This pull request resolves #248.

It makes two changes to `AudioSegment.export`:

1. If the `format` is specified as "raw" and `codec` or `parameters` are given, raise `AttributeError`
2. If the `format` is specified as "wav", only take the "save the file directly" shortcut if no `codec` or `parameters` are given (otherwise call ffmpeg as usual)

The reason for raising an exception in the "raw" case rather than calling ffmpeg is that "raw" is not actually an ffmpeg format. To invoke ffmpeg, we would need to parse the `codec` and `parameters` to infer the correct format to use (there is a list [here](https://trac.ffmpeg.org/wiki/audio%20types)), which may be difficult or impossible depending on their contents. I thought it would be cleaner to raise an exception suggesting to use the desired format directly (or remove the codec and parameters).

Unit tests are included for both the exception-raising raw case and the non-easy wav case.

The function's documentation is also cleaned up a little bit. I hope it's OK to do this in the same PR as the code changes.