### PR TITLE
Add try/finally to pyaudio to stop stream gracefully despite interrupts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,3 +78,6 @@ Antonio Larrosa
 
 Aaron Craig
     github: craigthelinguist
+
+Yudong Sun
+    github: sunjerry019

--- a/pydub/playback.py
+++ b/pydub/playback.py
@@ -28,22 +28,25 @@ def _play_with_pyaudio(seg):
                     rate=seg.frame_rate,
                     output=True)
 
-    # break audio into half-second chunks (to allows keyboard interrupts)
-    for chunk in make_chunks(seg, 500):
-        stream.write(chunk._data)
+    # Just in case there were any exceptions/interrupts, we release the resource
+    # So as not to raise OSError: Device Unavailable should play() be used again
+    try:
+        # break audio into half-second chunks (to allows keyboard interrupts)
+        for chunk in make_chunks(seg, 500):
+            stream.write(chunk._data)
+    finally:
+        stream.stop_stream()
+        stream.close()
 
-    stream.stop_stream()
-    stream.close()
-
-    p.terminate()
+        p.terminate()
 
 
 def _play_with_simpleaudio(seg):
     import simpleaudio
     return simpleaudio.play_buffer(
-        seg.raw_data, 
-        num_channels=seg.channels, 
-        bytes_per_sample=seg.sample_width, 
+        seg.raw_data,
+        num_channels=seg.channels,
+        bytes_per_sample=seg.sample_width,
         sample_rate=seg.frame_rate
     )
 
@@ -59,7 +62,7 @@ def play(audio_segment):
         pass
     else:
         return
-    
+
     try:
         _play_with_pyaudio(audio_segment)
         return
@@ -67,5 +70,5 @@ def play(audio_segment):
         pass
     else:
         return
-    
+
     _play_with_ffplay(audio_segment)


### PR DESCRIPTION
Steps to Reproduce Issue:
1. Suppose you have the following code and you are using `pyaudio`:
```Python
from pydub import AudioSegment
from pydub.playback import play

A = AudioSegment.from_wav("audio.wav")  # perhaps 3 minutes long
B = AudioSegment.from_wav("audio2.wav") # perhaps a shutdown tone

try:
    play(A)
except KeyboardInterrupt as e:
    pass

play(B)
```
2. When this code is run and you hit Ctrl + C during the playback of the first audio file `A`, audio file `B` will not play, instead raising an error:
```
OSError: [Errno -9985] Device unavailable
```

This means that if an audio playback was abruptly ended, we cannot play another audio file unless we rerun the python script.

System:
```
OS: Arch Linux x86_64 Linux 5.2.11-arch1-1-ARCH
Python: 3.7.4
Packages: pydub==0.23.1. PyAudio==0.2.11
```

Proposed Solution in this PR:
1. We ensure that the stream is stopped and closed every single time by adding a try and finally around the play code:

```Python
try:
    # break audio into half-second chunks (to allows keyboard interrupts)
    for chunk in make_chunks(seg, 500):
        stream.write(chunk._data)
finally:
    stream.stop_stream()
    stream.close()

    p.terminate()
```