### PR TITLE
Guard WAV header patching against >4GB files

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -137,6 +137,10 @@ def fix_wav_headers(data):
     if not headers or headers[-1].id != b'data':
         return
 
+    # TODO: Handle huge files in some other way
+    if len(data) > 2**32:
+        raise CouldntDecodeError("Unable to process >4GB files")
+
     # Set the file size in the RIFF chunk descriptor
     data[4:8] = struct.pack('<I', len(data) - 8)
 


### PR DESCRIPTION
Enormous files can cause fix_wav_headers() to bomb out. It'd be great if they could be properly parsed, but failing that, at least raise CouldntDecodeError instead of crashing out with a struct error.