### PR TITLE
Allow simpleaudio playback to be non-blocking

### DIFF
--- a/pydub/playback.py
+++ b/pydub/playback.py
@@ -51,9 +51,11 @@ def _play_with_simpleaudio(seg):
     )
 
 
-def play(audio_segment):
+def play(audio_segment, block=True):
     try:
         playback = _play_with_simpleaudio(audio_segment)
+        if !block:
+            return
         try:
             playback.wait_done()
         except KeyboardInterrupt:

--- a/pydub/playback.py
+++ b/pydub/playback.py
@@ -54,7 +54,7 @@ def _play_with_simpleaudio(seg):
 def play(audio_segment, block=True):
     try:
         playback = _play_with_simpleaudio(audio_segment)
-        if !block:
+        if not block:
             return
         try:
             playback.wait_done()


### PR DESCRIPTION
## Summary

This PR adds an optional parameter to the `play()` method that should allow playback to be non-blocking.  The parameter defaults to `True`, so there shouldn't be any breaking changes.

## Background

By default, [simpleaudio playback is synchronous](https://simpleaudio.readthedocs.io/en/latest/capabilities.html#asynchronous-interface):

> The module implements an asynchronous interface, meaning that program execution continues immediately after audio playback is started and a background thread takes care of the rest.

It would be useful if `play()` had at least optional non-blocking behavior so that it can be used in scenarios where there might be multiple audio segments being played at once, or so that it doesn't prevent other things from happening.

## Missing pieces

I haven't included any tests because there aren't any existing ones for `play` and I'm not really sure where I should add them.  I also noticed that the playback package is undocumented so I haven't added documentation anywhere.  For now I can add an inline comment in order to explain the change if you think it would be helpful.