### PR TITLE
fix bug in split_on_silence

### DIFF
--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -109,11 +109,6 @@ def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, ke
         default: 100ms
     """
 
-    if isinstance(keep_silence, bool):
-        keep_silence = len(audio_segment) if keep_silence else 0
-
-    not_silence_ranges = detect_nonsilent(audio_segment, min_silence_len, silence_thresh, seek_step)
-
     # from the itertools documentation
     def pairwise(iterable):
         "s -> (s0,s1), (s1,s2), (s2, s3), ..."
@@ -121,21 +116,27 @@ def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, ke
         next(b, None)
         return zip(a, b)
 
-    start_min = 0
-    chunks = []
-    for (start_i, end_i), (start_ii, end_ii) in pairwise(not_silence_ranges):
-        end_max = end_i + (start_ii - end_i + 1)//2  # +1 for rounding with integer division
-        start_i = max(start_min, start_i - keep_silence)
-        end_i = min(end_max, end_i + keep_silence)
+    if isinstance(keep_silence, bool):
+        keep_silence = len(audio_segment) if keep_silence else 0
 
-        chunks.append(audio_segment[start_i:end_i])
-        start_min = end_max
-
-    chunks.append(audio_segment[max(start_min, start_ii - keep_silence):
-                                min(len(audio_segment), end_ii + keep_silence)])
+    output_ranges = [
+        [ start - keep_silence, end + keep_silence ]
+        for (start,end)
+            in detect_nonsilent(audio_segment, min_silence_len, silence_thresh, seek_step)
+    ]
 
 
-    return chunks
+    if output_ranges:
+        output_ranges[0][0] = max(0,output_ranges[0][0])
+        for range_i, range_ii in pairwise(output_ranges):
+            last_end = range_i[1]
+            next_start = range_ii[0]
+            if next_start < last_end:
+                range_i[1] = (last_end+next_start)//2
+                range_ii[0] = range_i[1]
+        output_ranges[-1][1] = min(len(audio_segment),output_ranges[-1][1])
+
+    return [ audio_segment[start:end] for start,end in output_ranges ]
 
 
 def detect_leading_silence(sound, silence_threshold=-50.0, chunk_size=10):

--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -125,18 +125,17 @@ def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, ke
             in detect_nonsilent(audio_segment, min_silence_len, silence_thresh, seek_step)
     ]
 
+    for range_i, range_ii in pairwise(output_ranges):
+        last_end = range_i[1]
+        next_start = range_ii[0]
+        if next_start < last_end:
+            range_i[1] = (last_end+next_start)//2
+            range_ii[0] = range_i[1]
 
-    if output_ranges:
-        output_ranges[0][0] = max(0,output_ranges[0][0])
-        for range_i, range_ii in pairwise(output_ranges):
-            last_end = range_i[1]
-            next_start = range_ii[0]
-            if next_start < last_end:
-                range_i[1] = (last_end+next_start)//2
-                range_ii[0] = range_i[1]
-        output_ranges[-1][1] = min(len(audio_segment),output_ranges[-1][1])
-
-    return [ audio_segment[start:end] for start,end in output_ranges ]
+    return [
+        audio_segment[ max(start,0) : min(end,len(audio_segment)) ]
+        for start,end in output_ranges
+    ]
 
 
 def detect_leading_silence(sound, silence_threshold=-50.0, chunk_size=10):

--- a/test/test.py
+++ b/test/test.py
@@ -30,6 +30,7 @@ from pydub.exceptions import (
 )
 from pydub.silence import (
     detect_silence,
+    split_on_silence,
 )
 from pydub.generators import (
     Sine,
@@ -1093,6 +1094,20 @@ class SilenceTests(unittest.TestCase):
 
         self.seg1 = test1wav
         self.seg4 = test4wav
+
+    def test_split_on_silence_complete_silence(self):
+        seg = AudioSegment.silent(5000)
+        self.assertEquals( split_on_silence(seg), [] )
+
+    def test_split_on_silence_test1(self):
+        self.assertEqual(
+            len(split_on_silence(self.seg1, min_silence_len=500, silence_thresh=-20)),
+            3
+        )
+    def test_split_on_silence_no_silence(self):
+        splits = split_on_silence(self.seg1, min_silence_len=5000, silence_thresh=-200, keep_silence=True)
+        lens = [len(split) for split in splits]
+        self.assertEqual( lens, [len(self.seg1)] )
 
     def test_detect_completely_silent_segment(self):
         seg = AudioSegment.silent(5000)


### PR DESCRIPTION
This adds a test for and fixes the bug in issue #481,
which appears when calling split_on_silence on a audio segment that  is silent (entirely under the silence threshhold).