### PR TITLE
Instantiate AudioSegment in from_file, instead of using _from_safe_wav

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -726,7 +726,8 @@ class AudioSegment(object):
 
         p_out = bytearray(p_out)
         fix_wav_headers(p_out)
-        obj = cls._from_safe_wav(BytesIO(p_out))
+        p_out = bytes(p_out)
+        obj = cls(p_out)
 
         if close_file:
             file.close()


### PR DESCRIPTION
Hello,
I previously made a pull request (#453) which failed under Python 2.7. After thinking about it some more, I also realized that using a bytearray changed things in a pretty major way by making AudioSegments mutable. So I went back to the drawing board. The graphs in #453 still apply, so I won't repeat them here, but here are some new ones from the Fil memory profiler.
Prior to the change (pydub at master):

![fil-profile-master](https://user-images.githubusercontent.com/799153/84426251-86c45e80-abe8-11ea-93f9-9245c5fcba9c.png)

And after the change:
![fil-profile-change](https://user-images.githubusercontent.com/799153/84426369-ba9f8400-abe8-11ea-9089-7d3d1f8abffd.png)

This is the memory usage of opening a 57MB MP3 file using `from_file` and changing the sample rate to 16000.

The only change to pydub is replacing the call to `_from_safe_wav` with an instantiation of the class directly. Since `_from_safe_wav` just reads the BytesIO object and instantiates the class using the bytes, this should be exactly the same as before in every way, except with fewer copies of the data getting made.

Thank you for your time! 