### PR TITLE
Square the fade volume change for even power transition

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -1284,7 +1284,7 @@ class AudioSegment(object):
             scale_step = gain_delta / duration
 
             for i in range(duration):
-                volume_change = from_power + (scale_step * i)
+                volume_change = (from_power + (scale_step * i)) ** 0.5
                 chunk = self[start + i]
                 chunk = audioop.mul(chunk._data,
                                     self.sample_width,
@@ -1298,7 +1298,7 @@ class AudioSegment(object):
             scale_step = gain_delta / fade_frames
 
             for i in range(int(fade_frames)):
-                volume_change = from_power + (scale_step * i)
+                volume_change = (from_power + (scale_step * i)) ** 0.5
                 sample = self.get_frame(int(start_frame + i))
                 sample = audioop.mul(sample, self.sample_width, volume_change)
 


### PR DESCRIPTION
Currently the crossfade seems to result in a dip in volume - as I understand it you need to use the square of the volume to result in a smooth power level.

Disclaimer: I know very little about audio, I just tried to understand [this post][1]

NOTE: This also alters the behaviour of the `fade_in` and `fade_out` functions, I expect in a desirably way.
But I would understand if you want to add an extra flag to these/the `append` function for fade method, would be interested to hear what terminology to use for the argument if so.

[1]: https://dsp.stackexchange.com/questions/14754/equal-power-crossfade