### PR TITLE
Add step_fun curve to fade()

### DIFF
--- a/API.markdown
+++ b/API.markdown
@@ -359,6 +359,8 @@ no_crossfade2 = sound1 + sound2
 
 - `crossfade` | example: `3000` | default: `100` (entire duration of `AudioSegment`)
   When specified, method returns number of frames in X milliseconds of the `AudioSegment`
+- `step_fun` | example: `lambda x: x*x` | default: `lambda x: x`
+  Fade curve on the fading-in sound, default is linear (see `.fade()`); the fading-out sound will use `1-step_fun(x)`
 
 ### AudioSegment(…).overlay()
 
@@ -429,6 +431,17 @@ fade_quieter_beteen_2_and_3_seconds = sound1.fade(to_gain=-3.5, start=2000, end=
 # easy way is to use the .fade_in() convenience method. note: -120dB is basically silent.
 fade_in_the_hard_way = sound1.fade(from_gain=-120.0, start=0, duration=5000)
 fade_out_the_hard_way = sound1.fade(to_gain=-120.0, end=0, duration=5000)
+
+# controlling the fade curve
+def ease_in(x):
+  return x * x   # a number between 0 and 1 squared, curved up instead of linear;
+                 # the same function will work for fading up (+gain) or down (-gain)
+import math
+def ease_out(x):
+  return math.sqrt(x)   # curve down: apply the change faster
+                        # at the beginning of the fade and slower at the end
+
+fade_louder_abruptly = sound1.fade(to_gain=+6.0, start=7500, duration=3000, step_fun=ease_in)
 ```
 
 **Supported keyword arguments**:
@@ -443,6 +456,8 @@ fade_out_the_hard_way = sound1.fade(to_gain=-120.0, end=0, duration=5000)
   The overlaid `AudioSegment` will repeat X times (starting at `position`) but will still be truncated to the length of this `AudioSegment`
 - `duration` | example: `4` | NO DEFAULT
   You can use `start` or `end` with duration, instead of specifying both - provided as a convenience.
+- `step_fun` | example: `lambda x: x*x` | default: `lambda x: x`
+  Function from `[0..1]` to `[0..1]`: gives control over the curve of the fade; the default is a linear movement. For examples, see http://easings.net
 
 ### AudioSegment(…).fade_out()
 
@@ -452,6 +467,8 @@ Fade out (to silent) the end of this `AudioSegment`. Uses `.fade()` internally.
 
 - `duration` | example: `5000` | NO DEFAULT
   How long (in milliseconds) the fade should last. Passed directly to `.fade()` internally
+- `step_fun` | example: `lambda x: x*x` | default: `lambda x: x`
+  Fade curve, default is linear; as in `.fade()`
 
 ### AudioSegment(…).fade_in()
 
@@ -461,6 +478,8 @@ Fade in (from silent) the beginning of this `AudioSegment`. Uses `.fade()` inter
 
 - `duration` | example: `5000` | NO DEFAULT
   How long (in milliseconds) the fade should last. Passed directly to `.fade()` internally
+- `step_fun` | example: `lambda x: x*x` | default: `lambda x: x`
+  Fade curve, default is linear; as in `.fade()`
 
 ### AudioSegment(…).reverse()
 

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -1188,7 +1188,7 @@ class AudioSegment(object):
 
         return spawn(data=output)
 
-    def append(self, seg, crossfade=100):
+    def append(self, seg, crossfade=100, step_fun=lambda x: x):
         seg1, seg2 = AudioSegment._sync(self, seg)
 
         if not crossfade:
@@ -1202,8 +1202,8 @@ class AudioSegment(object):
                 crossfade, len(seg)
             ))
 
-        xf = seg1[-crossfade:].fade(to_gain=-120, start=0, end=float('inf'))
-        xf *= seg2[:crossfade].fade(from_gain=-120, start=0, end=float('inf'))
+        xf = seg1[-crossfade:].fade(to_gain=-120, start=0, end=float('inf'), step_fun=lambda x: 1 - step_fun(x))
+        xf *= seg2[:crossfade].fade(from_gain=-120, start=0, end=float('inf'), step_fun=step_fun)
 
         output = TemporaryFile()
 
@@ -1217,7 +1217,7 @@ class AudioSegment(object):
         return obj
 
     def fade(self, to_gain=0, from_gain=0, start=None, end=None,
-             duration=None):
+             duration=None, step_fun=lambda x: x):
         """
         Fade the volume of this audio segment.
 
@@ -1235,6 +1235,10 @@ class AudioSegment(object):
         duration (int):
             default = until the end of the audio segment
             the duration of the fade
+
+        step_fun (float -> float):
+            allow the user to control the fade curve (linear by default);
+            a function from [0..1] to [0..1]
         """
         if None not in [duration, end, start]:
             raise TypeError('Only two of the three arguments, "start", '
@@ -1281,10 +1285,11 @@ class AudioSegment(object):
         # shorter fades will have audible clicks so they use precise fading
         # (one gain step per sample)
         if duration > 100:
-            scale_step = gain_delta / duration
+            scale_step = 1.0 / duration
 
             for i in range(duration):
-                volume_change = from_power + (scale_step * i)
+                volume_change = from_power + \
+                    gain_delta * step_fun(i * scale_step)
                 chunk = self[start + i]
                 chunk = audioop.mul(chunk._data,
                                     self.sample_width,
@@ -1295,10 +1300,11 @@ class AudioSegment(object):
             start_frame = self.frame_count(ms=start)
             end_frame = self.frame_count(ms=end)
             fade_frames = end_frame - start_frame
-            scale_step = gain_delta / fade_frames
+            scale_step = 1.0 / fade_frames
 
             for i in range(int(fade_frames)):
-                volume_change = from_power + (scale_step * i)
+                volume_change = from_power + \
+                    gain_delta * step_fun(i * scale_step)
                 sample = self.get_frame(int(start_frame + i))
                 sample = audioop.mul(sample, self.sample_width, volume_change)
 
@@ -1314,11 +1320,11 @@ class AudioSegment(object):
 
         return self._spawn(data=output)
 
-    def fade_out(self, duration):
-        return self.fade(to_gain=-120, duration=duration, end=float('inf'))
+    def fade_out(self, duration, step_fun=lambda x: x):
+        return self.fade(to_gain=-120, duration=duration, end=float('inf'), step_fun=step_fun)
 
-    def fade_in(self, duration):
-        return self.fade(from_gain=-120, duration=duration, start=0)
+    def fade_in(self, duration, step_fun=lambda x: x):
+        return self.fade(from_gain=-120, duration=duration, start=0, step_fun=step_fun)
 
     def reverse(self):
         return self._spawn(


### PR DESCRIPTION
Adds a function to fade(), in order to control the fade curve (other than the current linear fade).

Apologies for sending an untested pull; I'm unsure about testing without messing with my pip installation.

In any case, this is intended as a suggestion; you may want to change the public interface to something friendlier.
No need to credit authorship.

Thanks!