### PR TITLE
fix PyInstaller '--noconsole' option

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -592,7 +592,7 @@ class AudioSegment(object):
         log_conversion(conversion_command)
 
         with open(os.devnull, 'rb') as devnull:
-            p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         p_out, p_err = p.communicate()
 
         log_subprocess_output(p_out)
@@ -668,7 +668,6 @@ class AudioSegment(object):
         read_ahead_limit = kwargs.get('read_ahead_limit', -1)
         if filename:
             conversion_command += ["-i", filename]
-            stdin_parameter = None
             stdin_data = None
         else:
             if cls.converter == 'ffmpeg':
@@ -676,7 +675,6 @@ class AudioSegment(object):
                                        "-i", "cache:pipe:0"]
             else:
                 conversion_command += ["-i", "-"]
-            stdin_parameter = subprocess.PIPE
             stdin_data = file.read()
 
         if codec:
@@ -713,8 +711,8 @@ class AudioSegment(object):
 
         log_conversion(conversion_command)
 
-        p = subprocess.Popen(conversion_command, stdin=stdin_parameter,
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(conversion_command, stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         p_out, p_err = p.communicate(input=stdin_data)
 
         if p.returncode != 0 or len(p_out) == 0:
@@ -901,7 +899,7 @@ class AudioSegment(object):
 
         # read stdin / write stdout
         with open(os.devnull, 'rb') as devnull:
-            p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         p_out, p_err = p.communicate()
 
         log_subprocess_output(p_out)

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -271,7 +271,7 @@ def mediainfo_json(filepath, read_ahead_limit=-1):
             file.close()
 
     command = [prober, '-of', 'json'] + command_args
-    res = Popen(command, stdin=stdin_parameter, stdout=PIPE, stderr=PIPE)
+    res = Popen(command, stdin=stdin_parameter, stdout=PIPE, stderr=PIPE, shell=True)
     output, stderr = res.communicate(input=stdin_data)
     output = output.decode("utf-8", 'ignore')
     stderr = stderr.decode("utf-8", 'ignore')
@@ -331,12 +331,12 @@ def mediainfo(filepath):
     ]
 
     command = [prober, '-of', 'old'] + command_args
-    res = Popen(command, stdout=PIPE)
+    res = Popen(command, stdout=PIPE, shell=True)
     output = res.communicate()[0].decode("utf-8")
 
     if res.returncode != 0:
         command = [prober] + command_args
-        output = Popen(command, stdout=PIPE).communicate()[0].decode("utf-8")
+        output = Popen(command, stdout=PIPE, shell=True).communicate()[0].decode("utf-8")
 
     rgx = re.compile(r"(?:(?P<inner_dict>.*?):)?(?P<key>.*?)\=(?P<value>.*?)$")
     info = {}
@@ -382,7 +382,7 @@ def cache_codecs(function):
 def get_supported_codecs():
     encoder = get_encoder_name()
     command = [encoder, "-codecs"]
-    res = Popen(command, stdout=PIPE, stderr=PIPE)
+    res = Popen(command, stdout=PIPE, stderr=PIPE, shell=True)
     output = res.communicate()[0].decode("utf-8")
     if res.returncode != 0:
         return []


### PR DESCRIPTION
fixed 'OSError: [WinError 6] The handle is invalid'
fixed command prompts appearing

original issue:
https://stackoverflow.com/questions/62058911/pydub-winerror-6-the-handle-is-invalid-while-using-audiosegment-from-file