### PR TITLE
Note that the format can be autodetected

### DIFF
--- a/API.markdown
+++ b/API.markdown
@@ -91,7 +91,7 @@ The first argument is the path (as a string) of the file to read, **or** a file 
 
 **Supported keyword arguments**:
 
-- `format` | example: `"aif"` | default: `"mp3"`
+- `format` | example: `"aif"` | default: autodetected
   Format of the output file. Supports `"wav"` and `"raw"` natively, requires ffmpeg for all other formats. `"raw"` files require 3 additional keyword arguments, `sample_width`, `frame_rate`, and `channels`, denoted below with: **`raw` only**. This extra info is required because raw audio files do not have headers to include this info in the file itself like wav files do.
 - `sample_width` | example: `2`
   **`raw` only** — Use `1` for 8-bit audio `2` for 16-bit (CD quality) and `4` for 32-bit. It’s the number of bytes per sample.


### PR DESCRIPTION
The format for `from_file` doesn't actually default to MP3. See here:

https://github.com/jiaaro/pydub/blob/23779fdb186fe66e4252e61062f36c1ffa229bb9/pydub/audio_segment.py#L659-L666

This updates the documentation to reflect that.