### PR TITLE
Consistency with file descriptor outputs

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -839,6 +839,7 @@ class AudioSegment(object):
 
         # for easy wav files, we're done (wav data is written directly to out_f)
         if easy_wav:
+            out_f.seek(0)
             return out_f
 
         output = NamedTemporaryFile(mode="w+b", delete=False)


### PR DESCRIPTION
In `AudioSegment.export` the file descriptor is always returned after doing a `seek(0)` except when it's an "easy wav".
It is problematic when we want to use it after exporting it (our use case is uploading it on S3 using `s3.Object().put(Body=file_d)`