### PR TITLE
explicitly block stdin in ffmpeg when it is not in use

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -713,6 +713,10 @@ class AudioSegment(object):
             conversion_command += ["-i", filename]
             stdin_parameter = None
             stdin_data = None
+            if cls.converter == 'ffmpeg':
+                conversion_command += ["-nostdin"]
+            else:
+                pass
         else:
             if cls.converter == 'ffmpeg':
                 conversion_command += ["-read_ahead_limit", str(read_ahead_limit),

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name='pydub',
-    version='0.25.1',
+    version='0.25.2',
     author='James Robert',
     author_email='jiaaro@gmail.com',
     description='Manipulate audio with an simple and easy high level interface',


### PR DESCRIPTION
While using `pydub` to process audio files in background via `ffmpeg`, it turned out that `ffmpeg` interferes with `stding` of the main process when it reads data from a file while `stdin` in inherited from Python.
This PR adds `ffmpeg`-specific command line argument (`-nostdin`) in the case when the input for `ffmpeg` is a file.