### PR TITLE
Fix #575: invalid option: --with-libvorbis

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -210,12 +210,12 @@ Mac (using [homebrew](http://brew.sh)):
 
 ```bash
 # libav
-brew install libav --with-libvorbis --with-sdl --with-theora
+brew install libav
 
 ####    OR    #####
 
 # ffmpeg
-brew install ffmpeg --with-libvorbis --with-sdl2 --with-theora
+brew install ffmpeg
 ```
 
 Linux (using aptitude):


### PR DESCRIPTION
Homebrew stopped supporting the `--with-libvorbis` option in late 2018.
According to OliverSparrow: The brew formulas for libav and ffmpeg now automatically install these files, listing them as dependencies. Just running `brew install libav` or `ffmpeg` alone should work now.