### PR TITLE
Fix typo in documentation

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -338,7 +338,7 @@ class AudioSegment(object):
         """
         Get a section of the audio segment by sample index.
 
-        NOTE: Negative indices do *not* address samples backword
+        NOTE: Negative indices do *not* address samples backward
         from the end of the audio segment like a python list.
         This is intentional.
         """


### PR DESCRIPTION
Just fixing a misspelled word in `AudioSegment.get_sample_slice` documentation ("backword"/"backward").