### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/API.markdown
+++ b/API.markdown
@@ -318,7 +318,7 @@ raw_audio_data = sound.raw_data
 
 ### AudioSegment(…).frame_count()
 
-Returns the number of frames in the `AudioSegment`. Optionally you may pass in a `ms` keywork argument to retrieve the number of frames in that number of milliseconds of audio in the `AudioSegment` (useful for slicing, etc).
+Returns the number of frames in the `AudioSegment`. Optionally you may pass in a `ms` keyword argument to retrieve the number of frames in that number of milliseconds of audio in the `AudioSegment` (useful for slicing, etc).
 
 ```python
 from pydub import AudioSegment
@@ -479,7 +479,7 @@ Creates an equivalent version of this `AudioSegment` with the specified frame ra
 
 ### AudioSegment(…).set_channels()
 
-Creates an equivalent version of this `AudioSegment` with the specified number of channels (1 is Mono, 2 is Stereo). Converting from mono to stereo does not cause any audible change. Converting from stereo to mono may result in loss of quality (but only if the left and right chanels differ).
+Creates an equivalent version of this `AudioSegment` with the specified number of channels (1 is Mono, 2 is Stereo). Converting from mono to stereo does not cause any audible change. Converting from stereo to mono may result in loss of quality (but only if the left and right channels differ).
 
 ### AudioSegment(…).split_to_mono()
 
@@ -491,7 +491,7 @@ Splits a stereo `AudioSegment` into two, one for each channel (Left/Right). Retu
 from pydub import AudioSegment
 sound1 = AudioSegment.from_file("sound1.wav")
 
-# make left channel 6dB quieter and right channe 2dB louder
+# make left channel 6dB quieter and right channel 2dB louder
 stereo_balance_adjusted = sound1.apply_gain_stereo(-6, +2)
 ```
 Apply gain to the left and right channel of a stereo `AudioSegment`. If the `AudioSegment` is mono, it will be converted to stereo before applying the gain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 - Fix crashing bug in new scipy-powered EQ effects
 
 # v0.25.0
-- Don't show a runtime warning about the optional ffplay dependency being missing until someone trys to use it
+- Don't show a runtime warning about the optional ffplay dependency being missing until someone tries to use it
 - Documentation improvements
 - Python 3.9 support
 - Improved efficiency of loading wave files with `pydub.AudioSegment.from_file()`
-- Ensure `pydub.AudioSegment().export()` always retuns files with a seek position at the beginning of the file   
+- Ensure `pydub.AudioSegment().export()` always returns files with a seek position at the beginning of the file   
 - Added more EQ effects to `pydub.scipy_effects` (requires scipy to be installed)
 - Fix a packaging bug where the LICENSE file was not included in the source distribution
 - Add a way to instantiate a `pydub.AudioSegment()` with a portion of an audio file via `pydub.AudioSegment().from_file()`

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -154,7 +154,7 @@ class AudioSegment(object):
     AudioSegments are *immutable* objects representing segments of audio
     that can be manipulated using python code.
 
-    AudioSegments are slicable using milliseconds.
+    AudioSegments are sliceable using milliseconds.
     for example:
         a = AudioSegment.from_mp3(mp3file)
         first_second = a[:1000] # get the first second of an mp3
@@ -338,7 +338,7 @@ class AudioSegment(object):
         """
         Get a section of the audio segment by sample index.
 
-        NOTE: Negative indices do *not* address samples backword
+        NOTE: Negative indices do *not* address samples backward
         from the end of the audio segment like a python list.
         This is intentional.
         """
@@ -844,7 +844,7 @@ class AudioSegment(object):
             -a:b).
 
         parameters (list of strings)
-            Aditional ffmpeg/avconv parameters
+            Additional ffmpeg/avconv parameters
 
         tags (dict)
             Set metadata information to destination files
@@ -1174,7 +1174,7 @@ class AudioSegment(object):
     def overlay(self, seg, position=0, loop=False, times=None, gain_during_overlay=None):
         """
         Overlay the provided segment on to this segment starting at the
-        specificed position and using the specfied looping beahvior.
+        specified position and using the specified looping beahvior.
 
         seg (AudioSegment):
             The audio segment to overlay on to this one.
@@ -1198,7 +1198,7 @@ class AudioSegment(object):
         """
 
         if loop:
-            # match loop=True's behavior with new times (count) mechinism.
+            # match loop=True's behavior with new times (count) mechanism.
             times = -1
         elif times is None:
             # no times specified, just once through

--- a/pydub/effects.py
+++ b/pydub/effects.py
@@ -120,7 +120,7 @@ def compress_dynamic_range(seg, threshold=-20.0, ratio=4.0, attack=5.0, release=
         threshold - default: -20.0
             Threshold in dBFS. default of -20.0 means -20dB relative to the
             maximum possible volume. 0dBFS is the maximum possible value so
-            all values for this argument sould be negative.
+            all values for this argument should be negative.
 
         ratio - default: 4.0
             Compression ratio. Audio louder than the threshold will be 

--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -14,7 +14,7 @@ def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, seek
     audio_segment - the segment to find silence in
     min_silence_len - the minimum length for any silent section
     silence_thresh - the upper bound for how quiet is silent in dFBS
-    seek_step - step size for interating over the segment in ms
+    seek_step - step size for iterating over the segment in ms
     """
     seg_len = len(audio_segment)
 
@@ -25,7 +25,7 @@ def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, seek
     # convert silence threshold to a float value (so we can compare it to rms)
     silence_thresh = db_to_float(silence_thresh) * audio_segment.max_possible_amplitude
 
-    # find silence and add start and end indicies to the to_cut list
+    # find silence and add start and end indices to the to_cut list
     silence_starts = []
 
     # check successive (1 sec by default) chunk of sound for silence
@@ -81,7 +81,7 @@ def detect_nonsilent(audio_segment, min_silence_len=1000, silence_thresh=-16, se
     audio_segment - the segment to find silence in
     min_silence_len - the minimum length for any silent section
     silence_thresh - the upper bound for how quiet is silent in dFBS
-    seek_step - step size for interating over the segment in ms
+    seek_step - step size for iterating over the segment in ms
     """
     silent_ranges = detect_silence(audio_segment, min_silence_len, silence_thresh, seek_step)
     len_seg = len(audio_segment)
@@ -131,7 +131,7 @@ def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, ke
         If True is specified, all the silence is kept, if False none is kept.
         default: 100ms
 
-    seek_step - step size for interating over the segment in ms
+    seek_step - step size for iterating over the segment in ms
     """
 
     # from the itertools documentation
@@ -169,7 +169,7 @@ def detect_leading_silence(sound, silence_threshold=-50.0, chunk_size=10):
 
     audio_segment - the segment to find silence in
     silence_threshold - the upper bound for how quiet is silent in dFBS
-    chunk_size - chunk size for interating over the segment in ms
+    chunk_size - chunk size for iterating over the segment in ms
     """
     trim_ms = 0 # ms
     assert chunk_size > 0 # to avoid infinite loop

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -159,7 +159,7 @@ def which(program):
 
 def get_encoder_name():
     """
-    Return enconder default application for system, either avconv or ffmpeg
+    Return encoder default application for system, either avconv or ffmpeg
     """
     if which("avconv"):
         return "avconv"
@@ -173,7 +173,7 @@ def get_encoder_name():
 
 def get_player_name():
     """
-    Return enconder default application for system, either avconv or ffmpeg
+    Return encoder default application for system, either avconv or ffmpeg
     """
     if which("avplay"):
         return "avplay"


### PR DESCRIPTION
Fix typos discovered by [`codespell`](https://pypi.org/project/codespell) in #618.