### PR TITLE
Bug & Enhancement: add make_time_chunks function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -96,3 +96,6 @@ Daniel Lefevre
 
 Grzegorz Kotfis
     github: gkotfis
+
+Rodrigo Cabrera Castaldoni
+    github: rocabrera

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -131,12 +131,24 @@ def register_pydub_effect(fn, name=None):
 
 def make_chunks(audio_segment, chunk_length):
     """
+    Breaks an AudioSegment into chunks each with <chunk_length> samples.
+    if chunk_length is 50 then you'll get a list of 50 samples until the end of the
+    audio file is reached.
+    segments back (except the last one, which can be shorter)
+    """
+    number_of_chunks = ceil(len(audio_segment) / float(chunk_length))
+    return [audio_segment[i * chunk_length:(i + 1) * chunk_length]
+            for i in range(int(number_of_chunks))]
+
+def make_time_chunks(audio_segment, chunk_length, sr=16000):
+    """
     Breaks an AudioSegment into chunks that are <chunk_length> milliseconds
     long.
     if chunk_length is 50 then you'll get a list of 50 millisecond long audio
     segments back (except the last one, which can be shorter)
     """
-    number_of_chunks = ceil(len(audio_segment) / float(chunk_length))
+    points_per_chunk = (float(chunk_length)/1000)*sr
+    number_of_chunks = ceil(len(audio_segment) / points_per_chunk)
     return [audio_segment[i * chunk_length:(i + 1) * chunk_length]
             for i in range(int(number_of_chunks))]
 

--- a/test/test.py
+++ b/test/test.py
@@ -1,6 +1,7 @@
 from functools import partial
 import os
 import sys
+from math import ceil
 import unittest
 from tempfile import (
     NamedTemporaryFile,
@@ -16,6 +17,7 @@ from pydub.utils import (
     db_to_float,
     ratio_to_db,
     make_chunks,
+    make_time_chunks,
     mediainfo,
     get_encoder_name,
     get_supported_decoders,
@@ -942,6 +944,12 @@ class AudioSegmentTests(unittest.TestCase):
         for chunk in chunks[1:]:
             seg2 += chunk
         self.assertEqual(len(seg), len(seg2))
+
+    def test_make_time_chunks(self):
+        seg1_chunks = make_time_chunks(self.seg1, 100, sr=self.seg1.frame_rate)
+        points_per_chunk = (float(100)/1000)*self.seg1.frame_rate
+        n_chunks = ceil(len(self.seg1) / points_per_chunk)
+        self.assertEqual(n_chunks, len(seg1_chunks))
 
     def test_empty(self):
         self.assertEqual(len(self.seg1), len(self.seg1 + AudioSegment.empty()))


### PR DESCRIPTION
### Steps to reproduce

```python
import librosa

from pydub.utils import make_chunks

sr = 16000
array, sr = librosa.load("328734__up
[328734__upasnarayan__clarinet-phrase.zip](https://github.com/jiaaro/pydub/files/7782442/328734__upasnarayan__clarinet-phrase.zip)
[328734__upasnarayan__clarinet-phrase.zip](https://github.com/jiaaro/pydub/files/7782443/328734__upasnarayan__clarinet-phrase.zip)
asnarayan__clarinet-phrase.wav", sr=sr)

chunks = make_chunks(array, 2000)

print(len(chunks))
```

### Expected behavior
The audio has approximately 4.2 seconds. I want chunks of 2000 ms so it should print 3

### Actual behavior

However, it's printing 34... This is happening because the function isn't taking the audio sample rate into account, so ```chunk_len``` is not the time in milliseconds, but the number of points a chunk has

### Your System configuration
- Python version: 3.9
- Pydub version: v0.25.1 (latest)
- ffmpeg or avlib?:  Not using
- ffmpeg/avlib version: Not using


### What hae I done

I change the documentation from the make_chunks function as I understand and create a new function called make_time_chunks which use the sample rate of the audio to create the chunks.

I hope it helps, awesome package.
