### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ setup(
     license='MIT',
     keywords='audio sound high-level',
     url='http://pydub.com',
+    project_urls={
+        'Source': 'https://github.com/jiaaro/pydub',
+    },
     packages=['pydub'],
     long_description=__doc__,
     classifiers=[


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)