### PR TITLE
Added NO_WINDOW flag

### DIFF
--- a/pydub/__init__.py
+++ b/pydub/__init__.py
@@ -1,1 +1,7 @@
+import os
+try:
+    _ = os.environ['PYDUB_NO_WINDOW']
+except KeyError:
+    os.environ["PYDUB_NO_WINDOW"] = "0"
+
 from .audio_segment import AudioSegment

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -42,6 +42,14 @@ from .exceptions import (
     MissingAudioParameter,
 )
 
+match os.environ['PYDUB_NO_WINDOW']:
+    case '0':
+        NO_WINDOW = False
+    case '1':
+        NO_WINDOW = True
+    case _:
+        NO_WINDOW = False
+
 if sys.version_info >= (3, 0):
     basestring = str
     xrange = range
@@ -613,7 +621,10 @@ class AudioSegment(object):
         log_conversion(conversion_command)
 
         with open(os.devnull, 'rb') as devnull:
-            p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if NO_WINDOW:
+                p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE, creationflags=subprocess.CREATE_NO_WINDOW)
+            else:
+                p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p_out, p_err = p.communicate()
 
         log_subprocess_output(p_out)
@@ -763,8 +774,14 @@ class AudioSegment(object):
 
         log_conversion(conversion_command)
 
-        p = subprocess.Popen(conversion_command, stdin=stdin_parameter,
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if NO_WINDOW:
+            p = subprocess.Popen(conversion_command, stdin=stdin_parameter,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 creationflags=subprocess.CREATE_NO_WINDOW)
+        else:
+            p = subprocess.Popen(conversion_command, stdin=stdin_parameter,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            
         p_out, p_err = p.communicate(input=stdin_data)
 
         if p.returncode != 0 or len(p_out) == 0:
@@ -960,7 +977,11 @@ class AudioSegment(object):
 
         # read stdin / write stdout
         with open(os.devnull, 'rb') as devnull:
-            p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if NO_WINDOW:
+                p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE, creationflags=subprocess.CREATE_NO_WINDOW)
+            else:
+                p = subprocess.Popen(conversion_command, stdin=devnull, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                
         p_out, p_err = p.communicate()
 
         log_subprocess_output(p_out)

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -10,6 +10,14 @@ from tempfile import TemporaryFile
 from warnings import warn
 from functools import wraps
 
+match os.environ['PYDUB_NO_WINDOW']:
+    case '0':
+        NO_WINDOW = False
+    case '1':
+        NO_WINDOW = True
+    case _:
+        NO_WINDOW = False
+
 try:
     import audioop
 except ImportError:
@@ -271,7 +279,10 @@ def mediainfo_json(filepath, read_ahead_limit=-1):
             file.close()
 
     command = [prober, '-of', 'json'] + command_args
-    res = Popen(command, stdin=stdin_parameter, stdout=PIPE, stderr=PIPE)
+    if NO_WINDOW:
+        res = Popen(command, stdin=stdin_parameter, stdout=PIPE, stderr=PIPE, creationflags=CREATE_NO_WINDOW)
+    else:
+        res = Popen(command, stdin=stdin_parameter, stdout=PIPE, stderr=PIPE)
     output, stderr = res.communicate(input=stdin_data)
     output = output.decode("utf-8", 'ignore')
     stderr = stderr.decode("utf-8", 'ignore')


### PR DESCRIPTION
Added NO_WINDOW flag for hiding the console windows that would pop up when calling `AudioSegment.from_file()`. Great for GUI making as it would run silently without any console windows showing up suddenly.

It is disabled by default. To enable it, simply set the environment variable `PYDUB_NO_WINDOW` with a value of `"1"`.
```py
import os
os.environ['PYDUB_NO_WINDOW'] = '1'
```