### PR TITLE
Fix for #604 (`json.loads()` on an empty string)

### DIFF
--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -276,11 +276,13 @@ def mediainfo_json(filepath, read_ahead_limit=-1):
     output = output.decode("utf-8", 'ignore')
     stderr = stderr.decode("utf-8", 'ignore')
 
-    info = json.loads(output)
-
-    if not info:
+    try:
+	info = json.loads(output)
+    except  json.decoder.JSONDecodeError:
         # If ffprobe didn't give any information, just return it
         # (for example, because the file doesn't exist)
+        return None
+    if not info:
         return info
 
     extra_info = get_extra_info(stderr)

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -277,7 +277,7 @@ def mediainfo_json(filepath, read_ahead_limit=-1):
     stderr = stderr.decode("utf-8", 'ignore')
 
     try:
-	info = json.loads(output)
+        info = json.loads(output)
     except  json.decoder.JSONDecodeError:
         # If ffprobe didn't give any information, just return it
         # (for example, because the file doesn't exist)


### PR DESCRIPTION
See #604