### PR TITLE
Delete temporary files in AudioSegment.export()

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -967,6 +967,12 @@ class AudioSegment(object):
         log_subprocess_output(p_err)
 
         if p.returncode != 0:
+            data.close()
+            output.close()
+
+            os.unlink(data.name)
+            os.unlink(output.name)
+
             raise CouldntEncodeError(
                 "Encoding failed. ffmpeg/avlib returned error code: {0}\n\nCommand:{1}\n\nOutput from ffmpeg/avlib:\n\n{2}".format(
                     p.returncode, conversion_command, p_err.decode(errors='ignore') ))


### PR DESCRIPTION
When `AudioSegment.export()` encounters an error, the `raise CouldntEncodeError` statement prevents the cleanup of the two temporary files, which happens just after that code block.

Setting `delete=True` in the constructors of these two `NamedTemporaryFile` objects causes other problems, so the simplest solution is to repeat the clean up code just before raising the exception.

In our project, these temporary files accumulate because our test suite exercises exporting to an unsupported format, catching the exception and recovering by exporting to a fallback format. But each time, this happens, we get two temporary files that don't get cleaned up.

Submitting this PR to correct the situation.