### PR TITLE
Improve consistency for detect_leading_silence method

### DIFF
--- a/API.markdown
+++ b/API.markdown
@@ -680,7 +680,7 @@ Returns the millisecond/index that the leading silence ends. If there is no end 
 ```python
 from pydub import AudioSegment, silence
 
-print(silence.detect_silence(AudioSegment.silent(2000)))
+print(silence.detect_leading_silence(AudioSegment.silent(2000)))
 # 2000
 ```
 

--- a/API.markdown
+++ b/API.markdown
@@ -686,7 +686,7 @@ print(silence.detect_leading_silence(AudioSegment.silent(2000)))
 
 **Supported keyword arguments**:
 
-- `silence_thresh` | example: `-20` | default: -50
+- `silence_thresh` | example: `-20` | default: -16
   The upper bound for how quiet is silent in dBFS.
 
 - `chunk_size` | example: `5` | default: 10

--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -163,20 +163,20 @@ def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, ke
     ]
 
 
-def detect_leading_silence(sound, silence_threshold=-50.0, chunk_size=10):
+def detect_leading_silence(audio_segment, silence_thresh=-16, chunk_size=10):
     """
     Returns the millisecond/index that the leading silence ends.
 
     audio_segment - the segment to find silence in
-    silence_threshold - the upper bound for how quiet is silent in dFBS
+    silence_thresh - the upper bound for how quiet is silent in dFBS
     chunk_size - chunk size for interating over the segment in ms
     """
     trim_ms = 0 # ms
     assert chunk_size > 0 # to avoid infinite loop
-    while sound[trim_ms:trim_ms+chunk_size].dBFS < silence_threshold and trim_ms < len(sound):
+    while audio_segment[trim_ms:trim_ms+chunk_size].dBFS < silence_thresh and trim_ms < len(audio_segment):
         trim_ms += chunk_size
 
     # if there is no end it should return the length of the segment
-    return min(trim_ms, len(sound))
+    return min(trim_ms, len(audio_segment))
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -29,6 +29,7 @@ from pydub.exceptions import (
     MissingAudioParameter,
 )
 from pydub.silence import (
+    detect_leading_silence,
     detect_silence,
     split_on_silence,
 )
@@ -1144,6 +1145,15 @@ class SilenceTests(unittest.TestCase):
         silent_ranges = detect_silence(self.seg1, min_silence_len=500, silence_thresh=-20,
                                        seek_step=10)
         self.assertEqual(silent_ranges, [[0, 770], [3150, 4030], [5520, 6050]])
+
+    def test_detect_leading_silence_completely_silent_segment(self):
+        seg = AudioSegment.silent(5000)
+        silence_ending = detect_leading_silence(seg, silence_thresh=-20)
+        self.assertEqual(silence_ending, 5000)
+
+    def test_detect_leading_silence_seg1(self):
+        silence_ending = detect_leading_silence(self.seg1, silence_thresh=-20)
+        self.assertEqual(silence_ending, 380)
 
     def test_realistic_audio(self):
         silent_ranges = detect_silence(self.seg4, min_silence_len=1000, silence_thresh=self.seg4.dBFS)


### PR DESCRIPTION
Hello @jiaaro! Thank you for your library ☀️ 

While using it I found some inconsistencies between documentation and source code and I decided to prepare this pull request.

Changes:
  - fixed example in API documentation for detect_leading_silence
  - renamed first argument from "sound" to "audio_segment" to be consistent with documentation and other methods
  - renamed argument "silence_threshold" to "silence_thresh" (breaking change) to be consistent with other methods and changed default value from -50.0 to -16
  - added 2 tests for detect_leading_silence