### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -338,7 +338,7 @@ class AudioSegment(object):
         """
         Get a section of the audio segment by sample index.
 
-        NOTE: Negative indices do *not* address samples backword
+        NOTE: Negative indices do *not* address samples backward
         from the end of the audio segment like a python list.
         This is intentional.
         """
@@ -1174,7 +1174,7 @@ class AudioSegment(object):
     def overlay(self, seg, position=0, loop=False, times=None, gain_during_overlay=None):
         """
         Overlay the provided segment on to this segment starting at the
-        specificed position and using the specfied looping beahvior.
+        specified position and using the specfied looping beahvior.
 
         seg (AudioSegment):
             The audio segment to overlay on to this one.

--- a/pydub/effects.py
+++ b/pydub/effects.py
@@ -120,7 +120,7 @@ def compress_dynamic_range(seg, threshold=-20.0, ratio=4.0, attack=5.0, release=
         threshold - default: -20.0
             Threshold in dBFS. default of -20.0 means -20dB relative to the
             maximum possible volume. 0dBFS is the maximum possible value so
-            all values for this argument sould be negative.
+            all values for this argument should be negative.
 
         ratio - default: 4.0
             Compression ratio. Audio louder than the threshold will be 

--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -14,7 +14,7 @@ def detect_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, seek
     audio_segment - the segment to find silence in
     min_silence_len - the minimum length for any silent section
     silence_thresh - the upper bound for how quiet is silent in dFBS
-    seek_step - step size for interating over the segment in ms
+    seek_step - step size for iterating over the segment in ms
     """
     seg_len = len(audio_segment)
 
@@ -81,7 +81,7 @@ def detect_nonsilent(audio_segment, min_silence_len=1000, silence_thresh=-16, se
     audio_segment - the segment to find silence in
     min_silence_len - the minimum length for any silent section
     silence_thresh - the upper bound for how quiet is silent in dFBS
-    seek_step - step size for interating over the segment in ms
+    seek_step - step size for iterating over the segment in ms
     """
     silent_ranges = detect_silence(audio_segment, min_silence_len, silence_thresh, seek_step)
     len_seg = len(audio_segment)
@@ -131,7 +131,7 @@ def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, ke
         If True is specified, all the silence is kept, if False none is kept.
         default: 100ms
 
-    seek_step - step size for interating over the segment in ms
+    seek_step - step size for iterating over the segment in ms
     """
 
     # from the itertools documentation
@@ -169,7 +169,7 @@ def detect_leading_silence(sound, silence_threshold=-50.0, chunk_size=10):
 
     audio_segment - the segment to find silence in
     silence_threshold - the upper bound for how quiet is silent in dFBS
-    chunk_size - chunk size for interating over the segment in ms
+    chunk_size - chunk size for iterating over the segment in ms
     """
     trim_ms = 0 # ms
     assert chunk_size > 0 # to avoid infinite loop


### PR DESCRIPTION
There are small typos in:
- pydub/audio_segment.py
- pydub/effects.py
- pydub/silence.py

Fixes:
- Should read `iterating` rather than `interating`.
- Should read `specified` rather than `specificed`.
- Should read `should` rather than `sould`.
- Should read `backward` rather than `backword`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md