### PR TITLE
Add BufferedReader to instances to close check

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -96,3 +96,6 @@ Daniel Lefevre
 
 Grzegorz Kotfis
     github: gkotfis
+
+Pål Orby
+    github: orby

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from io import BufferedReader
 
 import json
 import os
@@ -58,6 +59,9 @@ def _fd_or_path_or_tempfile(fd, mode='w+b', tempfile=True):
 
     if isinstance(fd, basestring):
         fd = open(fd, mode=mode)
+        close_fd = True
+
+    if isinstance(fd, BufferedReader):
         close_fd = True
 
     try:


### PR DESCRIPTION
If you call `audio_segment = AudioSegment.from_wav('any_wav_file.wav')` you will get a warning that the file is not closed. 
This fix will return `close_fd = True` when fd is an instance of BufferedReader and that buffer will be closed.