### PR TITLE
Fix a bug in `parameters` variable

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -598,6 +598,10 @@ class AudioSegment(object):
             "-f", "wav"  # output options (filename last)
         ]
 
+        if parameters is not None:
+            # extend arguments with arbitrary set
+            conversion_command.extend(parameters)
+
         if start_second is not None:
             conversion_command += ["-ss", str(start_second)]
 
@@ -605,10 +609,6 @@ class AudioSegment(object):
             conversion_command += ["-t", str(duration)]
 
         conversion_command += [output.name]
-
-        if parameters is not None:
-            # extend arguments with arbitrary set
-            conversion_command.extend(parameters)
 
         log_conversion(conversion_command)
 
@@ -722,6 +722,10 @@ class AudioSegment(object):
             stdin_parameter = subprocess.PIPE
             stdin_data = file.read()
 
+        if parameters is not None:
+            # extend arguments with arbitrary set
+            conversion_command.extend(parameters)
+
         if codec:
             info = None
         else:
@@ -756,10 +760,6 @@ class AudioSegment(object):
             conversion_command += ["-t", str(duration)]
 
         conversion_command += ["-"]
-
-        if parameters is not None:
-            # extend arguments with arbitrary set
-            conversion_command.extend(parameters)
 
         log_conversion(conversion_command)
 

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -503,7 +503,7 @@ class AudioSegment(object):
         )
 
     @classmethod
-    def from_file_using_temporary_files(cls, file, format=None, codec=None, parameters=None, start_second=None, duration=None, **kwargs):
+    def from_file_using_temporary_files(cls, file, format=None, codec=None, parameters=None, start_second=None, duration=None, force_conversion=False, **kwargs):
         orig_file = file
         file, close_file = _fd_or_path_or_tempfile(file, 'rb', tempfile=False)
 
@@ -521,7 +521,7 @@ class AudioSegment(object):
                 return orig_file.lower().endswith((".{0}".format(f)).encode('utf8'))
             return False
 
-        if is_format("wav"):
+        if is_format("wav") and not force_conversion:
             try:
                 obj = cls._from_safe_wav(file)
                 if close_file:
@@ -642,7 +642,7 @@ class AudioSegment(object):
 
 
     @classmethod
-    def from_file(cls, file, format=None, codec=None, parameters=None, start_second=None, duration=None, **kwargs):
+    def from_file(cls, file, format=None, codec=None, parameters=None, start_second=None, duration=None, force_conversion=False, **kwargs):
         orig_file = file
         try:
             filename = fsdecode(file)
@@ -664,7 +664,7 @@ class AudioSegment(object):
 
             return False
 
-        if is_format("wav"):
+        if is_format("wav") and not force_conversion:
             try:
                 if start_second is None and duration is None:
                     return cls._from_safe_wav(file)

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -503,7 +503,7 @@ class AudioSegment(object):
         )
 
     @classmethod
-    def from_file_using_temporary_files(cls, file, format=None, codec=None, parameters=None, start_second=None, duration=None, force_conversion=False, **kwargs):
+    def from_file_using_temporary_files(cls, file, format=None, codec=None, parameters=None, start_second=None, duration=None, **kwargs):
         orig_file = file
         file, close_file = _fd_or_path_or_tempfile(file, 'rb', tempfile=False)
 
@@ -521,7 +521,7 @@ class AudioSegment(object):
                 return orig_file.lower().endswith((".{0}".format(f)).encode('utf8'))
             return False
 
-        if is_format("wav") and not force_conversion:
+        if is_format("wav") and parameters is None:
             try:
                 obj = cls._from_safe_wav(file)
                 if close_file:
@@ -642,7 +642,7 @@ class AudioSegment(object):
 
 
     @classmethod
-    def from_file(cls, file, format=None, codec=None, parameters=None, start_second=None, duration=None, force_conversion=False, **kwargs):
+    def from_file(cls, file, format=None, codec=None, parameters=None, start_second=None, duration=None, **kwargs):
         orig_file = file
         try:
             filename = fsdecode(file)
@@ -664,7 +664,7 @@ class AudioSegment(object):
 
             return False
 
-        if is_format("wav") and not force_conversion:
+        if is_format("wav") and parameters is None:
             try:
                 if start_second is None and duration is None:
                     return cls._from_safe_wav(file)

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -582,6 +582,13 @@ class AudioSegment(object):
         conversion_command = [cls.converter,
                               '-y',  # always overwrite existing files
                               ]
+ 
+        if start_second is not None:
+            conversion_command += ["-ss", str(start_second)]
+
+        if duration is not None:
+            end_second = start_second + duration
+            conversion_command += ["-to", str(end_second)]
 
         # If format is not defined
         # ffmpeg/avconv will detect it automatically
@@ -601,12 +608,6 @@ class AudioSegment(object):
         if parameters is not None:
             # extend arguments with arbitrary set
             conversion_command.extend(parameters)
-
-        if start_second is not None:
-            conversion_command += ["-ss", str(start_second)]
-
-        if duration is not None:
-            conversion_command += ["-t", str(duration)]
 
         conversion_command += [output.name]
 
@@ -631,14 +632,7 @@ class AudioSegment(object):
             os.unlink(input_file.name)
             os.unlink(output.name)
 
-        if start_second is None and duration is None:
-            return obj
-        elif start_second is not None and duration is None:
-            return obj[0:]
-        elif start_second is None and duration is not None:
-            return obj[:duration * 1000]
-        else:
-            return obj[0:duration * 1000]
+        return obj
 
 
     @classmethod
@@ -699,6 +693,13 @@ class AudioSegment(object):
                               '-y',  # always overwrite existing files
                               ]
 
+        if start_second is not None:
+            conversion_command += ["-ss", str(start_second)]
+
+        if duration is not None:
+            end_second = start_second + duration
+            conversion_command += ["-to", str(end_second)]
+
         # If format is not defined
         # ffmpeg/avconv will detect it automatically
         if format:
@@ -753,12 +754,6 @@ class AudioSegment(object):
             "-f", "wav"  # output options (filename last)
         ]
 
-        if start_second is not None:
-            conversion_command += ["-ss", str(start_second)]
-
-        if duration is not None:
-            conversion_command += ["-t", str(duration)]
-
         conversion_command += ["-"]
 
         log_conversion(conversion_command)
@@ -782,14 +777,8 @@ class AudioSegment(object):
         if close_file:
             file.close()
 
-        if start_second is None and duration is None:
-            return obj
-        elif start_second is not None and duration is None:
-            return obj[0:]
-        elif start_second is None and duration is not None:
-            return obj[:duration * 1000]
-        else:
-            return obj[0:duration * 1000]
+        return obj
+
 
     @classmethod
     def from_mp3(cls, file, parameters=None):


### PR DESCRIPTION
I was trying to read a very large MP4 file and convert to WAV so I provided some parameters to `from_file` function in the argument `parameters`.
My parameters were:
```python
parameters = ['-ac', '1', '-ar', '16000']
```
which means that the resultant audio file should have 16K sample rate and the number of channels should be 1 (mono) but that did not work!
After investigation, I found that the `parameters` are added it the end of the command and the command will be something like:
```bash
ffmpeg -y -i my_video.mp4 -acodec pcm_s16le -vn -f wav - -ac 1 -ar 16000
```
I changed it to add `parameters` in the middle where the command should look like this:

```bash
ffmpeg -y -i my_video.mp4 -ac 1 -ar 16000 -acodec pcm_s16le -vn -f wav -
```
and it worked!!