### PR TITLE
Switch from output seeking to combined input seeking and output seeking to accelerate extracting small segments from huge files

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -592,17 +592,17 @@ class AudioSegment(object):
             # force audio decoder
             conversion_command += ["-acodec", codec]
 
-        conversion_command += [
-            "-i", input_file.name,  # input_file options (filename last)
-            "-vn",  # Drop any video streams if there are any
-            "-f", "wav"  # output options (filename last)
-        ]
-
         if start_second is not None:
             conversion_command += ["-ss", str(start_second)]
 
         if duration is not None:
             conversion_command += ["-t", str(duration)]
+
+        conversion_command += [
+            "-i", input_file.name,  # input_file options (filename last)
+            "-vn",  # Drop any video streams if there are any
+            "-f", "wav"  # output options (filename last)
+        ]
 
         conversion_command += [output.name]
 
@@ -708,6 +708,12 @@ class AudioSegment(object):
             # force audio decoder
             conversion_command += ["-acodec", codec]
 
+        if start_second is not None:
+            conversion_command += ["-ss", str(start_second)]
+
+        if duration is not None:
+            conversion_command += ["-t", str(duration)]
+
         read_ahead_limit = kwargs.get('read_ahead_limit', -1)
         if filename:
             conversion_command += ["-i", filename]
@@ -748,12 +754,6 @@ class AudioSegment(object):
             "-vn",  # Drop any video streams if there are any
             "-f", "wav"  # output options (filename last)
         ]
-
-        if start_second is not None:
-            conversion_command += ["-ss", str(start_second)]
-
-        if duration is not None:
-            conversion_command += ["-t", str(duration)]
 
         conversion_command += ["-"]
 

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -592,17 +592,17 @@ class AudioSegment(object):
             # force audio decoder
             conversion_command += ["-acodec", codec]
 
-        if start_second is not None:
-            conversion_command += ["-ss", str(start_second)]
-
-        if duration is not None:
-            conversion_command += ["-t", str(duration)]
-
         conversion_command += [
             "-i", input_file.name,  # input_file options (filename last)
             "-vn",  # Drop any video streams if there are any
             "-f", "wav"  # output options (filename last)
         ]
+
+        if start_second is not None:
+            conversion_command += ["-ss", str(start_second)]
+
+        if duration is not None:
+            conversion_command += ["-t", str(duration)]
 
         conversion_command += [output.name]
 

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -770,13 +770,13 @@ class AudioSegment(object):
 
             conversion_command += ["-acodec", acodec]
 
-        if start_second is not None:
-            conversion_command += ["-ss", str(start_offset)]
-
         conversion_command += [
             "-vn",  # Drop any video streams if there are any
             "-f", "wav"  # output options (filename last)
         ]
+
+        if start_second is not None:
+            conversion_command += ["-ss", str(start_offset)]
 
         conversion_command += ["-"]
 

--- a/test/test.py
+++ b/test/test.py
@@ -1358,6 +1358,12 @@ class PartialAudioSegmentLoadTests(unittest.TestCase):
         partial_seg2 = AudioSegment.from_file(self.mp3_path_str, start_second=1., duration=1.)
         self.assertEqual(len(partial_seg1), len(partial_seg2))
         self.assertEqual(partial_seg1._data, partial_seg2._data)
+    
+    def test_partial_load_small_start_second_and_duration_equals_cropped_mp3_audio_segment(self):
+        partial_seg1 = AudioSegment.from_file(self.mp3_path_str)[10:1010]
+        partial_seg2 = AudioSegment.from_file(self.mp3_path_str, start_second=0.01, duration=1.)
+        self.assertEqual(len(partial_seg1), len(partial_seg2))
+        self.assertEqual(partial_seg1._data, partial_seg2._data)
 
     def test_partial_load_duration_equals_cropped_wav_audio_segment(self):
         partial_seg1 = AudioSegment.from_file(self.wave_path_str)[:1000]


### PR DESCRIPTION
Without this change, seeking inside a huge file gets slower the further you seek. E.g., if you want to have a small AudioSegment with 100 seconds starting from 7000 seconds, it may take up to 5 seconds to extract the segment. With this change, it takes less than a second!

I had the idea of trimming start and end positions with:
```
AudioSegment.from_file(
    file = "video.mp4",
    start_seconds = 7000,
    duration = 100,
)
```
But this took surprisingly long!

From analysing the command line I realized, that AudioSegment.from_file() was first specifying the input file and then the seek parameters:
```
'ffmpeg', '-y', '-i', 'video.mp4', '-ss', '7000', '-t', '100', ...
```
But when reading about the seek parameter for FFMPEG I understood from "https://trac.ffmpeg.org/wiki/Seeking", that actually:
_As of FFmpeg 2.1, when transcoding with ffmpeg (i.e. not [stream copying](https://ffmpeg.org/ffmpeg.html#Stream-copy)), -ss is now also "frame-accurate" even when used as an input option..._

So I tried instead the following command:
```
'ffmpeg', '-y', '-ss', '7000', '-t', '100', '-i', 'video.mp4', ...
```
... and the video file was processed incredibly much faster!

When the pull request first ran through a test with an mp3 file failed:
test_partial_load_start_second_and_duration_equals_cropped_mp3_audio_segment

The reason was that input seeking is not accurate for encoded streams! So I had to add some margin in the input seeking. I tried to calculate the maximum required margin based on the properties of the stream. Let me know, if it makes sense for you as well.
The approximate margin needed is ~144 ms.
At the end, we still need to seek the output stream, so the ffmpeg command would be

```
'ffmpeg', '-y', '-ss', '6999.856', '-t', '100.288', '-i', 'video.mp4', '-ss' '0.144' ...
```
