### PR TITLE
Change linear fade to square root fade (equal power crossfade)

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -1344,7 +1344,7 @@ class AudioSegment(object):
             scale_step = gain_delta / duration
 
             for i in range(duration):
-                volume_change = from_power + (scale_step * i)
+                volume_change = (from_power + (scale_step * i)) ** 0.5
                 chunk = self[start + i]
                 chunk = audioop.mul(chunk._data,
                                     self.sample_width,
@@ -1358,7 +1358,7 @@ class AudioSegment(object):
             scale_step = gain_delta / fade_frames
 
             for i in range(int(fade_frames)):
-                volume_change = from_power + (scale_step * i)
+                volume_change = (from_power + (scale_step * i)) ** 0.5
                 sample = self.get_frame(int(start_frame + i))
                 sample = audioop.mul(sample, self.sample_width, volume_change)
 

--- a/test/test.py
+++ b/test/test.py
@@ -678,7 +678,7 @@ class AudioSegmentTests(unittest.TestCase):
 
         self.assertEqual(len(inf_end), len(seg))
 
-        self.assertTrue(-6 < ratio_to_db(inf_end.rms, seg.rms) < -5)
+        self.assertWithinRange(ratio_to_db(inf_end.rms, seg.rms), -4, -3)
 
         # use a slice out of the middle to make sure there is audio
         seg = self.seg2[2000:8000]


### PR DESCRIPTION
When crossfading two segments, there is a slight dip in volume because the fade is linear. This PR makes fades perceptually smoother by taking the square root of the volume change, making it an [equal power crossfade](https://dsp.stackexchange.com/questions/14754/equal-power-crossfade).

The change is identical to that from #511, but includes a fixed test.