### PR TITLE
Fix audio segment export bigger 4gb

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -902,7 +902,12 @@ class AudioSegment(object):
             # For some reason packing the wave header struct with
             # a float in python 2 doesn't throw an exception
             # => we convert to int for setnframes
-            if len(pcm_for_wav) - array_position > max_size:
+
+            # For WAV files we still try to write the whole file at once, although
+            # it's clear, that it will fail for > 4gb, since the WAV file specification
+            # doesn't even foresee it, for any compressed format, we split into 
+            # WAV files < 4 GB and combine again with FFMPEG
+            if not easy_wav and len(pcm_for_wav) - array_position > max_size:
                 wave_data.setnframes(int(max_size/4))
                 wave_data.writeframesraw(pcm_for_wav[array_position:array_position+max_size])
                 array_position+=max_size

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -875,25 +875,42 @@ class AudioSegment(object):
         # wav with no ffmpeg parameters can just be written directly to out_f
         easy_wav = format == "wav" and codec is None and parameters is None
 
-        if easy_wav:
-            data = out_f
-        else:
-            data = NamedTemporaryFile(mode="wb", delete=False)
-
         pcm_for_wav = self._data
         if self.sample_width == 1:
             # convert to unsigned integers for wav
             pcm_for_wav = audioop.bias(self._data, 1, 128)
 
-        wave_data = wave.open(data, 'wb')
-        wave_data.setnchannels(self.channels)
-        wave_data.setsampwidth(self.sample_width)
-        wave_data.setframerate(self.frame_rate)
-        # For some reason packing the wave header struct with
-        # a float in python 2 doesn't throw an exception
-        wave_data.setnframes(int(self.frame_count()))
-        wave_data.writeframesraw(pcm_for_wav)
-        wave_data.close()
+        header_length = 40
+        max_size = 2**32 - header_length
+
+        file_completed = False
+        array_position = 0
+
+        data_files = []
+
+        while not file_completed:
+            if easy_wav:
+                data = out_f
+            else:
+                data = NamedTemporaryFile(mode="wb", delete=False)
+                data_files.append(data)
+
+            wave_data = wave.open(data, 'wb')
+            wave_data.setnchannels(self.channels)
+            wave_data.setsampwidth(self.sample_width)
+            wave_data.setframerate(self.frame_rate)
+            # For some reason packing the wave header struct with
+            # a float in python 2 doesn't throw an exception
+            # => we convert to int for setnframes
+            if len(pcm_for_wav) - array_position > max_size:
+                wave_data.setnframes(int(max_size/4))
+                wave_data.writeframesraw(pcm_for_wav[array_position:array_position+max_size])
+                array_position+=max_size
+            else:
+                wave_data.setnframes(int(len(pcm_for_wav[array_position:])/4))
+                wave_data.writeframesraw(pcm_for_wav[array_position:])
+                file_completed = True
+            wave_data.close()
 
         # for easy wav files, we're done (wav data is written directly to out_f)
         if easy_wav:
@@ -906,8 +923,10 @@ class AudioSegment(object):
         conversion_command = [
             self.converter,
             '-y',  # always overwrite existing files
-            "-f", "wav", "-i", data.name,  # input options (filename last)
+            "-f", "wav",  # input options (filename last)
         ]
+
+        conversion_command.extend(item for sublist in [["-i", data.name] for data in data_files] for item in sublist)
 
         if codec is None:
             codec = self.DEFAULT_CODECS.get(format, None)
@@ -976,9 +995,10 @@ class AudioSegment(object):
             out_f.write(output.read())
 
         finally:
-            data.close()
+            for data in data_files:
+                data.close()
+                os.unlink(data.name)
             output.close()
-            os.unlink(data.name)
             os.unlink(output.name)
 
         out_f.seek(0)

--- a/test/test.py
+++ b/test/test.py
@@ -1094,6 +1094,13 @@ class AudioSegmentTests(unittest.TestCase):
         tempfile.tempdir = orig_tmpdir
         os.rmdir(new_tmpdir)
 
+    def test_audio_segment_export_bigger_than_4gb(self):
+        original_path = os.path.join(data_dir,'test1.wav')
+        original_segment = AudioSegment.from_file(original_path)
+        while len(original_segment.raw_data) < 2**32:
+            original_segment += original_segment
+        with NamedTemporaryFile('w+b', suffix='.mp3') as tmp_file:
+            original_segment.export(tmp_file,format='mp3')
 
 class SilenceTests(unittest.TestCase):
 
@@ -1394,7 +1401,6 @@ class PartialAudioSegmentLoadTests(unittest.TestCase):
         partial_seg2 = AudioSegment.from_file(self.raw_path_str, format="raw", sample_width=2, frame_rate=32000, channels=2, start_second=1., duration=1.)
         self.assertEqual(len(partial_seg1), len(partial_seg2))
         self.assertEqual(partial_seg1._data, partial_seg2._data)
-
 
 if __name__ == "__main__":
     import sys

--- a/test/test.py
+++ b/test/test.py
@@ -1094,10 +1094,21 @@ class AudioSegmentTests(unittest.TestCase):
         tempfile.tempdir = orig_tmpdir
         os.rmdir(new_tmpdir)
 
-    def test_audio_segment_export_bigger_than_4gb(self):
+    # This test is disabled, since on the infrastructure, it throws an error:
+    # ERROR: test_audio_segment_export_bigger_than_4gb (main.AudioSegmentTests)
+    # Traceback (most recent call last):
+    # File "test/test.py", line 1104, in test_audio_segment_export_bigger_than_4gb
+    # original_segment += original_segment
+    # File "c:\projects\pydub\pydub\audio_segment.py", line 364, in add
+    # return self.append(arg, crossfade=0)
+    # File "c:\projects\pydub\pydub\audio_segment.py", line 1280, in append
+    # return seg1._spawn(seg1._data + seg2._data)
+    # MemoryError
+    def disabled_test_audio_segment_export_bigger_than_4gb(self):
         # Note: This is a very long running test, it takes about 26 seconds. But it is
         # required to ensure that a segment > 4 gb can still be correctly exported
         # to an MP3
+        assert(False)
         original_path = os.path.join(data_dir,'test1.wav')
         original_segment = AudioSegment.from_file(original_path)
         while len(original_segment.raw_data) < 2**32:


### PR DESCRIPTION
This pull request adds the possibility to export an AudioSegment, which is bigger than 4 GB to any compressed format. It does not allow to export the AudioSegment directly to a WAV file bigger than 4 GB.
Apparently it's not even allowed from the specification of the WAV file to be bigger than 4 GB.
The strategy for the compressed formats is to split the audio segment into Wave Files smaller 4 GB and then to combine them with FFMPEG.
Note:
I also added a test with an audio segment > 4 GB, which is taking quite some time. On my machine (Lenovo P50), it takes 26 seconds.
Additionally on the infrastructure, it's impossible to run it due to memory limitation:

ERROR: test_audio_segment_export_bigger_than_4gb (__main__.AudioSegmentTests)
Traceback (most recent call last):
  File "test/test.py", line 1104, in test_audio_segment_export_bigger_than_4gb
    original_segment += original_segment
  File "c:\projects\pydub\pydub\audio_segment.py", line 364, in __add__
    return self.append(arg, crossfade=0)
  File "c:\projects\pydub\pydub\audio_segment.py", line 1280, in append
    return seg1._spawn(seg1._data + seg2._data)
MemoryError

=> This test is there, it can be used to verify the issue and the fix, but I have to disable it.