### PR TITLE
Play WAV files with ffmpeg on Windows 21H2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,3 +99,6 @@ Grzegorz Kotfis
 
 Pål Orby
     github: orby
+
+Luca Cavasso
+    github: lcavasso

--- a/pydub/playback.py
+++ b/pydub/playback.py
@@ -12,6 +12,7 @@ from .utils import get_player_name, make_chunks
 def _play_with_ffplay(seg):
     PLAYER = get_player_name()
     with NamedTemporaryFile("w+b", suffix=".wav") as f:
+        f.close()
         seg.export(f.name, "wav")
         subprocess.call([PLAYER, "-nodisp", "-autoexit", "-hide_banner", f.name])
 


### PR DESCRIPTION
Recent Windows update brought issue 209 back. Followed comment https://github.com/jiaaro/pydub/issues/209#issuecomment-602260075 and was able to play a wav file successfully.