### PR TITLE
Fixing test warnings

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -664,132 +664,131 @@ class AudioSegment(object):
 
             return False
 
-        if is_format("wav"):
-            try:
+        try:
+            if is_format("wav"):
+                try:
+                    if start_second is None and duration is None:
+                        return cls._from_safe_wav(file)
+                    elif start_second is not None and duration is None:
+                        return cls._from_safe_wav(file)[start_second*1000:]
+                    elif start_second is None and duration is not None:
+                        return cls._from_safe_wav(file)[:duration*1000]
+                    else:
+                        return cls._from_safe_wav(file)[start_second*1000:(start_second+duration)*1000]
+                except:
+                    file.seek(0)
+            elif is_format("raw") or is_format("pcm"):
+                sample_width = kwargs['sample_width']
+                frame_rate = kwargs['frame_rate']
+                channels = kwargs['channels']
+                metadata = {
+                    'sample_width': sample_width,
+                    'frame_rate': frame_rate,
+                    'channels': channels,
+                    'frame_width': channels * sample_width
+                }
                 if start_second is None and duration is None:
-                    return cls._from_safe_wav(file)
+                    return cls(data=file.read(), metadata=metadata)
                 elif start_second is not None and duration is None:
-                    return cls._from_safe_wav(file)[start_second*1000:]
+                    return cls(data=file.read(), metadata=metadata)[start_second*1000:]
                 elif start_second is None and duration is not None:
-                    return cls._from_safe_wav(file)[:duration*1000]
+                    return cls(data=file.read(), metadata=metadata)[:duration*1000]
                 else:
-                    return cls._from_safe_wav(file)[start_second*1000:(start_second+duration)*1000]
-            except:
-                file.seek(0)
-        elif is_format("raw") or is_format("pcm"):
-            sample_width = kwargs['sample_width']
-            frame_rate = kwargs['frame_rate']
-            channels = kwargs['channels']
-            metadata = {
-                'sample_width': sample_width,
-                'frame_rate': frame_rate,
-                'channels': channels,
-                'frame_width': channels * sample_width
-            }
+                    return cls(data=file.read(), metadata=metadata)[start_second*1000:(start_second+duration)*1000]
+
+            conversion_command = [cls.converter,
+                                  '-y',  # always overwrite existing files
+                                  ]
+
+            # If format is not defined
+            # ffmpeg/avconv will detect it automatically
+            if format:
+                conversion_command += ["-f", format]
+
+            if codec:
+                # force audio decoder
+                conversion_command += ["-acodec", codec]
+
+            read_ahead_limit = kwargs.get('read_ahead_limit', -1)
+            if filename:
+                conversion_command += ["-i", filename]
+                stdin_parameter = None
+                stdin_data = None
+            else:
+                if cls.converter == 'ffmpeg':
+                    conversion_command += ["-read_ahead_limit", str(read_ahead_limit),
+                                           "-i", "cache:pipe:0"]
+                else:
+                    conversion_command += ["-i", "-"]
+                stdin_parameter = subprocess.PIPE
+                stdin_data = file.read()
+
+            if codec:
+                info = None
+            else:
+                info = mediainfo_json(orig_file, read_ahead_limit=read_ahead_limit)
+            if info:
+                audio_streams = [x for x in info['streams']
+                                 if x['codec_type'] == 'audio']
+                # This is a workaround for some ffprobe versions that always say
+                # that mp3/mp4/aac/webm/ogg files contain fltp samples
+                audio_codec = audio_streams[0].get('codec_name')
+                if (audio_streams[0].get('sample_fmt') == 'fltp' and
+                        audio_codec in ['mp3', 'mp4', 'aac', 'webm', 'ogg']):
+                    bits_per_sample = 16
+                else:
+                    bits_per_sample = audio_streams[0]['bits_per_sample']
+                if bits_per_sample == 8:
+                    acodec = 'pcm_u8'
+                else:
+                    acodec = 'pcm_s%dle' % bits_per_sample
+
+                conversion_command += ["-acodec", acodec]
+
+            conversion_command += [
+                "-vn",  # Drop any video streams if there are any
+                "-f", "wav"  # output options (filename last)
+            ]
+
+            if start_second is not None:
+                conversion_command += ["-ss", str(start_second)]
+
+            if duration is not None:
+                conversion_command += ["-t", str(duration)]
+
+            conversion_command += ["-"]
+
+            if parameters is not None:
+                # extend arguments with arbitrary set
+                conversion_command.extend(parameters)
+
+            log_conversion(conversion_command)
+
+            p = subprocess.Popen(conversion_command, stdin=stdin_parameter,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p_out, p_err = p.communicate(input=stdin_data)
+
+            if p.returncode != 0 or len(p_out) == 0:
+                raise CouldntDecodeError(
+                    "Decoding failed. ffmpeg returned error code: {0}\n\nOutput from ffmpeg/avlib:\n\n{1}".format(
+                        p.returncode, p_err.decode(errors='ignore') ))
+
+            p_out = bytearray(p_out)
+            fix_wav_headers(p_out)
+            p_out = bytes(p_out)
+            obj = cls(p_out)
+
             if start_second is None and duration is None:
-                return cls(data=file.read(), metadata=metadata)
+                return obj
             elif start_second is not None and duration is None:
-                return cls(data=file.read(), metadata=metadata)[start_second*1000:]
+                return obj[0:]
             elif start_second is None and duration is not None:
-                return cls(data=file.read(), metadata=metadata)[:duration*1000]
+                return obj[:duration * 1000]
             else:
-                return cls(data=file.read(), metadata=metadata)[start_second*1000:(start_second+duration)*1000]
-
-        conversion_command = [cls.converter,
-                              '-y',  # always overwrite existing files
-                              ]
-
-        # If format is not defined
-        # ffmpeg/avconv will detect it automatically
-        if format:
-            conversion_command += ["-f", format]
-
-        if codec:
-            # force audio decoder
-            conversion_command += ["-acodec", codec]
-
-        read_ahead_limit = kwargs.get('read_ahead_limit', -1)
-        if filename:
-            conversion_command += ["-i", filename]
-            stdin_parameter = None
-            stdin_data = None
-        else:
-            if cls.converter == 'ffmpeg':
-                conversion_command += ["-read_ahead_limit", str(read_ahead_limit),
-                                       "-i", "cache:pipe:0"]
-            else:
-                conversion_command += ["-i", "-"]
-            stdin_parameter = subprocess.PIPE
-            stdin_data = file.read()
-
-        if codec:
-            info = None
-        else:
-            info = mediainfo_json(orig_file, read_ahead_limit=read_ahead_limit)
-        if info:
-            audio_streams = [x for x in info['streams']
-                             if x['codec_type'] == 'audio']
-            # This is a workaround for some ffprobe versions that always say
-            # that mp3/mp4/aac/webm/ogg files contain fltp samples
-            audio_codec = audio_streams[0].get('codec_name')
-            if (audio_streams[0].get('sample_fmt') == 'fltp' and
-                    audio_codec in ['mp3', 'mp4', 'aac', 'webm', 'ogg']):
-                bits_per_sample = 16
-            else:
-                bits_per_sample = audio_streams[0]['bits_per_sample']
-            if bits_per_sample == 8:
-                acodec = 'pcm_u8'
-            else:
-                acodec = 'pcm_s%dle' % bits_per_sample
-
-            conversion_command += ["-acodec", acodec]
-
-        conversion_command += [
-            "-vn",  # Drop any video streams if there are any
-            "-f", "wav"  # output options (filename last)
-        ]
-
-        if start_second is not None:
-            conversion_command += ["-ss", str(start_second)]
-
-        if duration is not None:
-            conversion_command += ["-t", str(duration)]
-
-        conversion_command += ["-"]
-
-        if parameters is not None:
-            # extend arguments with arbitrary set
-            conversion_command.extend(parameters)
-
-        log_conversion(conversion_command)
-
-        p = subprocess.Popen(conversion_command, stdin=stdin_parameter,
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        p_out, p_err = p.communicate(input=stdin_data)
-
-        if p.returncode != 0 or len(p_out) == 0:
+                return obj[0:duration * 1000]
+        finally:
             if close_file:
                 file.close()
-            raise CouldntDecodeError(
-                "Decoding failed. ffmpeg returned error code: {0}\n\nOutput from ffmpeg/avlib:\n\n{1}".format(
-                    p.returncode, p_err.decode(errors='ignore') ))
-
-        p_out = bytearray(p_out)
-        fix_wav_headers(p_out)
-        p_out = bytes(p_out)
-        obj = cls(p_out)
-
-        if close_file:
-            file.close()
-
-        if start_second is None and duration is None:
-            return obj
-        elif start_second is not None and duration is None:
-            return obj[0:]
-        elif start_second is None and duration is not None:
-            return obj[:duration * 1000]
-        else:
-            return obj[0:duration * 1000]
 
     @classmethod
     def from_mp3(cls, file, parameters=None):

--- a/test/test.py
+++ b/test/test.py
@@ -1086,7 +1086,7 @@ class AudioSegmentTests(unittest.TestCase):
             tmp_wav_file.flush()
             self.assertRaises(CouldntDecodeError, AudioSegment.from_file, tmp_wav_file.name)
             files = os.listdir(tempfile.tempdir)
-            self.assertEquals(files, [os.path.basename(tmp_wav_file.name)])
+            self.assertEqual(files, [os.path.basename(tmp_wav_file.name)])
 
         if sys.platform == 'win32':
             os.remove(tmp_wav_file.name)
@@ -1109,7 +1109,7 @@ class SilenceTests(unittest.TestCase):
 
     def test_split_on_silence_complete_silence(self):
         seg = AudioSegment.silent(5000)
-        self.assertEquals( split_on_silence(seg), [] )
+        self.assertEqual( split_on_silence(seg), [] )
 
     def test_split_on_silence_test1(self):
         self.assertEqual(

--- a/test/test.py
+++ b/test/test.py
@@ -151,8 +151,9 @@ if sys.version_info >= (3, 6):
             seg1 = AudioSegment.from_file(self.mp3_path_str)
             from pathlib import Path
             path = Path(tempfile.gettempdir()) / 'pydub-test-export-8ajds.mp3'
+            out_f = None
             try:
-                seg1.export(path, format='mp3')
+                out_f = seg1.export(path, format='mp3')
                 seg2 = AudioSegment.from_file(path, format='mp3')
 
                 self.assertTrue(len(seg1) > 0)
@@ -160,6 +161,8 @@ if sys.version_info >= (3, 6):
                                            len(seg2),
                                            percentage=0.01)
             finally:
+                if out_f:
+                    out_f.close()
                 os.unlink(path)
 
 
@@ -280,7 +283,8 @@ class AudioSegmentTests(unittest.TestCase):
         path = os.path.join(data_dir, base_file)
         base = AudioSegment.from_file(path)
 
-        headers = extract_wav_headers(open(path, 'rb').read())
+        with open(path, 'rb') as f:
+            headers = extract_wav_headers(f.read())
         data16_size = headers[-1].size
         self.assertEqual(len(base.raw_data), data16_size)
         self.assertEqual(base.frame_rate, 192000)
@@ -489,7 +493,8 @@ class AudioSegmentTests(unittest.TestCase):
             if sys.platform == 'win32':
                 tmp_file.close()
 
-            mono.export(tmp_file.name, 'mp3')
+            out_f = mono.export(tmp_file.name, 'mp3')
+            out_f.close()
             monomp3 = AudioSegment.from_mp3(tmp_file.name)
 
             self.assertWithinTolerance(
@@ -1282,7 +1287,9 @@ class NoConverterTests(unittest.TestCase):
 
     def test_exporting(self):
         seg = AudioSegment.from_wav(self.wave_file)
-        exported = AudioSegment.from_wav(seg.export(format="wav"))
+        out_f = seg.export(format="wav")
+        exported = AudioSegment.from_wav(out_f)
+        out_f.close()
 
         self.assertEqual(len(exported), len(seg))
 

--- a/test/test.py
+++ b/test/test.py
@@ -640,6 +640,8 @@ class AudioSegmentTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             seg.export(format='raw', parameters=['-ar', '16000', '-ac', '1'])
 
+    @unittest.skipUnless('libvorbis' in get_supported_encoders(),
+                         "Unsupported codecs")
     def test_export_as_ogg(self):
         seg = self.seg1
         exported_ogg = seg.export(format='ogg')
@@ -649,6 +651,8 @@ class AudioSegmentTests(unittest.TestCase):
                                    len(seg),
                                    percentage=0.01)
 
+    @unittest.skipUnless('libvorbis' in get_supported_encoders(),
+                         "Unsupported codecs")
     def test_export_forced_codec(self):
         seg = self.seg1 + self.seg2
 
@@ -779,6 +783,8 @@ class AudioSegmentTests(unittest.TestCase):
             AudioSegment.from_file(self.ogg_file_path).export(tmp_mp3_file,
                                                               format="mp3")
 
+    @unittest.skipUnless('libvorbis' in get_supported_encoders(),
+                         "Unsupported codecs")
     def test_export_mp3_as_ogg(self):
         with NamedTemporaryFile('w+b', suffix='.ogg') as tmp_ogg_file:
             AudioSegment.from_file(self.mp3_file_path).export(tmp_ogg_file,
@@ -796,7 +802,7 @@ class AudioSegmentTests(unittest.TestCase):
             AudioSegment.from_file(self.mp3_file_path).export(tmp_webm_file,
                                                               format="webm")
 
-    @unittest.skipUnless('aac' in get_supported_decoders(),
+    @unittest.skipUnless('aac' in get_supported_decoders() and 'libvorbis' in get_supported_encoders(),
                          "Unsupported codecs")
     def test_export_mp4_as_ogg(self):
         with NamedTemporaryFile('w+b', suffix='.ogg') as tmp_ogg_file:
@@ -973,7 +979,7 @@ class AudioSegmentTests(unittest.TestCase):
         # average volume should be reduced
         self.assertTrue(compressed.rms < self.seg1.rms)
 
-    @unittest.skipUnless('aac' in get_supported_decoders(),
+    @unittest.skipUnless('aac' in get_supported_decoders() and 'libvorbis' in get_supported_encoders(),
                          "Unsupported codecs")
     def test_exporting_to_ogg_uses_default_codec_when_codec_param_is_none(self):
         delete = sys.platform != 'win32'


### PR DESCRIPTION
This fixes some errors and a number of warnings I got when running the tests:

- Some tests fail with ffmpeg error "Unknown encoder 'libvorbis'" - added skip condition if libvorbis is not a known encoder
- Many warnings about unclosed file handles - fixed in the tests and in relevant AudioSegment functions
- Deprecation warnings about assertEquals (should be assertEqual)