### PR TITLE
Improved detect silence

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
     keywords='audio sound high-level',
     url='http://pydub.com',
     packages=['pydub'],
+    install_requires=[
+        "numpy >= 1.16, < 2.0",
+    ],
     long_description=__doc__,
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/test/test.py
+++ b/test/test.py
@@ -1153,6 +1153,46 @@ class SilenceTests(unittest.TestCase):
             self.assertTrue(start > prev_end)
             prev_end = end
 
+    def test_detect_silence_noncontinous_without_gap(self):
+        raw_data = b"\xFF\x7F\xFF\x7F\x00\x00\x00\x00\xFF\x7F\x00\x00\xFF\x7F\x00\x00\x00\x00\xFF\x7F\xFF\x7F"
+        seg = AudioSegment(raw_data, frame_rate=1000, channels=1, sample_width=2)
+        
+        self.assertEqual(seg.frame_count(), 11.0)
+        self.assertEqual(len(seg), 11)
+        
+        silent_ranges = detect_silence(seg, min_silence_len=3, silence_thresh=-4, seek_step=1)
+        self.assertEqual(silent_ranges, [[1, 10]])
+    
+    def test_detect_silence_noncontinuous_with_gap(self):
+        raw_data = b"\xFF\x7F\xFF\x7F\x00\x00\x00\x00\xFF\x7F\xFF\x7F\xFF\x7F\x00\x00\x00\x00\xFF\x7F\xFF\x7F"
+        seg = AudioSegment(raw_data, frame_rate=1000, channels=1, sample_width=2)
+        
+        self.assertEqual(seg.frame_count(), 11.0)
+        self.assertEqual(len(seg), 11)
+        
+        silent_ranges = detect_silence(seg, min_silence_len=3, silence_thresh=-4, seek_step=1)
+        self.assertEqual(silent_ranges, [[1, 5], [6, 10]])
+    
+    def test_detect_silence_noncontinuous_without_gap_last_slice(self):
+        raw_data = b"\xFF\x7F\xFF\x7F\x00\x00\x00\x00\xFF\x7F\xFF\x7F\x00\x00\x00\x00"
+        seg = AudioSegment(raw_data, frame_rate=1000, channels=1, sample_width=2)
+        
+        self.assertEqual(seg.frame_count(), 8.0)
+        self.assertEqual(len(seg), 8)
+        
+        silent_ranges = detect_silence(seg, min_silence_len=3, silence_thresh=-4, seek_step=2)
+        self.assertEqual(silent_ranges, [[2, 8]])
+    
+    def test_detect_silence_noncontinuous_with_gap_last_slice(self):
+        raw_data = b"\xFF\x7F\xFF\x7F\x00\x00\x00\x00\xFF\x7F\xFF\x7F\xFF\x7F\x00\x00\xFF\x7F\x00\x00"
+        seg = AudioSegment(raw_data, frame_rate=1000, channels=1, sample_width=2)
+        
+        self.assertEqual(seg.frame_count(), 10.0)
+        self.assertEqual(len(seg), 10)
+        
+        silent_ranges = detect_silence(seg, min_silence_len=3, silence_thresh=-4, seek_step=2)
+        self.assertEqual(silent_ranges, [[2, 5], [7, 10]])
+
 
 class GeneratorTests(unittest.TestCase):
 


### PR DESCRIPTION
## Overview
Reimplementation of `detect_silence`: Previously this function would invoke RMS computations independently for each slice of `min_silence_len` in the given audio segment, which leads to a lot of recomputing of similar values of the `seek_step` is small. The new implementation avoids this, resulting in much smaller detection time.

## Caveats
This introduces numpy as a *new dependency*. This is for two reasons:

1. it makes the computation easy to express
2. it is very performant due to numpy being highly optimized for computations on large numeric arrays

While implementing this without numpy would be possible, it would likely not see the same amount of performance increase and easy of implementation.

`detect_silence` previously used audioop to compute RMS values of slices, which rounds the computed value down to the nearest integers  - the silence threshold is not rounded. This is no longer the case in the new implementation, resulting in some slices that were previously detected as silent to not be so anymore. In practice this means that _detected silent regions might be slightly shorter than before_ (by usually one or two `seek_step`s).

## Performance results
`%timeit` results on audio segments consisting mostly of silence

### 20 minute segment
```
# old
> %timeit detect_silence(aus_short, silence_thresh=-50, seek_step=1)
1min 36s ± 914 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# new
> %timeit detect_silence(aus_short, silence_thresh=-50, seek_step=1)
2.66 s ± 20.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

### ~114 minute segment
```ipython
# old
> %timeit detect_silence(aus, silence_thresh=-50, seek_step=1)
8min 37s ± 10.5 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

# new
> %timeit detect_silence(aus, silence_thresh=-50, seek_step=1)
15 s ± 392 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```