### PR TITLE
Fix converter custom parameter builder (AudioSegment.from_file)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,3 +99,6 @@ Grzegorz Kotfis
 
 Pål Orby
     github: orby
+
+Pedro Lira
+    github: pedrohml

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -755,11 +755,11 @@ class AudioSegment(object):
         if duration is not None:
             conversion_command += ["-t", str(duration)]
 
-        conversion_command += ["-"]
-
         if parameters is not None:
             # extend arguments with arbitrary set
             conversion_command.extend(parameters)
+
+        conversion_command += ["-"]
 
         log_conversion(conversion_command)
 


### PR DESCRIPTION
Shifts the **standard output** (-) parameter to be the last one in the converter parameters so custom input parameters can take effect for conversion using _ffmpeg_.

I have faced issues when using the parameter `-map` to select audio streams for conversion as it only take effect if before stdout parameter. 

Wrong:
```sh
ffmpeg -y -i input -f wav - -map 0:1 > test-wrong.wav
```

Right:
```sh
ffmpeg -y -i input -f wav -map 0:1 - > test-right.wav
```

In the examples above, only `test-right.wav` is successfully converted given the selected stream index (i.e. 1).

This follows the established usage instructions where the output destination should be the last parameter to specify (i.e. output_url):

```sh
ffmpeg [global_options] {[input_file_options] -i input_url} ... {[output_file_options] output_url} ...
```