### PR TITLE
Fix test assertions

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -1086,7 +1086,7 @@ class AudioSegmentTests(unittest.TestCase):
             tmp_wav_file.flush()
             self.assertRaises(CouldntDecodeError, AudioSegment.from_file, tmp_wav_file.name)
             files = os.listdir(tempfile.tempdir)
-            self.assertEquals(files, [os.path.basename(tmp_wav_file.name)])
+            self.assertEqual(files, [os.path.basename(tmp_wav_file.name)])
 
         if sys.platform == 'win32':
             os.remove(tmp_wav_file.name)
@@ -1109,7 +1109,7 @@ class SilenceTests(unittest.TestCase):
 
     def test_split_on_silence_complete_silence(self):
         seg = AudioSegment.silent(5000)
-        self.assertEquals( split_on_silence(seg), [] )
+        self.assertEqual( split_on_silence(seg), [] )
 
     def test_split_on_silence_test1(self):
         self.assertEqual(


### PR DESCRIPTION
`assertEquals()` was a deprecated alias for `assertEqual()` and has been removed in Python 3.12. See more [here](https://docs.python.org/3/whatsnew/3.12.html#id3). This pull request replaces all `assertEquals()` calls with `assertEqual()` calls. This allows the tests to be run on Python 3.12.