### PR TITLE
Added Start time property 

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -180,6 +180,7 @@ class AudioSegment(object):
         self.sample_width = kwargs.pop("sample_width", None)
         self.frame_rate = kwargs.pop("frame_rate", None)
         self.channels = kwargs.pop("channels", None)
+        self.start_time = kwargs.pop("start_time", None)
 
         audio_params = (self.sample_width, self.frame_rate, self.channels)
 

--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -157,11 +157,16 @@ def split_on_silence(audio_segment, min_silence_len=1000, silence_thresh=-16, ke
             range_i[1] = (last_end+next_start)//2
             range_ii[0] = range_i[1]
 
-    return [
-        audio_segment[ max(start,0) : min(end,len(audio_segment)) ]
-        for start,end in output_ranges
-    ]
+    audio_segment_chunks = []
+    for start, end in output_ranges:
+        start = max(start, 0)
+        end = min(end, len(audio_segment))
 
+        new_audio_segment = audio_segment[start:end]
+        new_audio_segment.start_time = start
+        audio_segment_chunks.append(new_audio_segment)
+
+    return audio_segment_chunks
 
 def detect_leading_silence(sound, silence_threshold=-50.0, chunk_size=10):
     """


### PR DESCRIPTION
# Release Notes - Pydub v0.25.2

## New Features

### AudioSegment Class
- Added a new property: `start_time`
  - Default value: `0`
  - The `start_time` property is now available for the `AudioSegment` class.
  - Updated automatically when using the `split_on_silence()` function.
  - During the creation of multiple chunks, `start_time` reflects the starting time of its parent `AudioSegment` object.

## How to Use
```python
from pydub import AudioSegment

# Create an AudioSegment instance
audio = AudioSegment.from_file("example.mp3")

# Access and modify the start_time property
start_time = audio.start_time  # Get the current start time, default: 0

# Use split_on_silence() to update start_time during chunk creation
chunks = split_on_silence(audio)

for chunk in chunks:
    print(f">> {chunk.start_time}, {chunk.duration_seconds*1000+chunk.start_time}")
```

Result:
```bash
>> 503, 3338.0
>> 3338, 6179.0
>> 6179, 7632.0
>> 7632, 13930.0
>> 13930, 18141.0
>> 18141, 20653.0
... ... ...
... ... ...
... ... ...

```