### PR TITLE
Fix the problem that pydub.playback() can't play 32bit audios with pyaudio correctly

### DIFF
--- a/pydub/playback.py
+++ b/pydub/playback.py
@@ -20,7 +20,11 @@ def _play_with_pyaudio(seg):
     import pyaudio
 
     p = pyaudio.PyAudio()
-    stream = p.open(format=p.get_format_from_width(seg.sample_width),
+    if seg.sample_width != 4:
+        format = p.get_format_from_width(seg.sample_width)
+    else:
+        format = pyaudio._portaudio.paInt32
+    stream = p.open(format=format,
                     channels=seg.channels,
                     rate=seg.frame_rate,
                     output=True)


### PR DESCRIPTION
pydub.playback() can't play 32bit audios with pyaudio correctly because p.get_format_from_width(seg.sample_width) returns "paFloat32" when seg.sample_width is 4, but chunk._data is actually a bunch of 32bit ints, which contradicts the "paFloat32" which means that floats should be given. therefore we will get a series of electronic noises instead of correct music sounds.

so, I fixed the problem by simply adding a judgment of seg.sample_width. if it's not 4, then use the original  method; If it is 4, then use "pyaudio._portaudio.paInt32" to output 32bit ints.