### PR TITLE
Resolve #784 https://github.com/jiaaro/pydub/issues/784

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -821,7 +821,8 @@ class AudioSegment(object):
             file.close()
         return obj
 
-    def export(self, out_f=None, format='mp3', codec=None, bitrate=None, parameters=None, tags=None, id3v2_version='4',
+    def export(self, out_f:str=None, format:str='mp3', codec:str=None, bitrate:str=None,
+               parameters=None, tags=None, id3v2_version:str='4',
                cover=None):
         """
         Export an AudioSegment to a file with given options

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -925,7 +925,7 @@ class AudioSegment(object):
             conversion_command.extend(["-acodec", codec])
 
         if bitrate is not None:
-            conversion_command.extend(["-b:a", bitrate])
+            conversion_command.extend(["-b:a", str(bitrate) if type(bitrate)==int else bitrate])
 
         if parameters is not None:
             # extend arguments with arbitrary set


### PR DESCRIPTION
This pull request is associated with issue #784: https://github.com/jiaaro/pydub/issues/784. Either of the commits in this pull request can be taken - they're not both needed, though it won't cause a problem if they're both taken.

 - Commit 1f4a152 adds type hints to the method definition (marking everything that the doc says is a string as required to be a string). There aren't type hints elsewhere in the pro
 - Commit 8146622 checks if the bitrate passed into the method is an int, and if it is, it recasts it as a string before adding it to the args list. If it's not present or any other type, it leaves it alone.