### PR TITLE
Python exception when calling AudioSegment.export() with bitrate of int type (Issue #784)

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -924,7 +924,7 @@ class AudioSegment(object):
             conversion_command.extend(["-acodec", codec])
 
         if bitrate is not None:
-            conversion_command.extend(["-b:a", bitrate])
+            conversion_command.extend(["-b:a", str(bitrate) if type(bitrate)==int else bitrate])
 
         if parameters is not None:
             # extend arguments with arbitrary set


### PR DESCRIPTION
This pull request is associated with issue https://github.com/jiaaro/pydub/issues/784.

The fix checks if the bitrate passed into the method is an int, and if it is, it recasts it as a string before adding it to the args list. If it's not present or any other type, it leaves it alone.