### PR TITLE
Fix bug in exporting to wav format with tags

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,3 +99,6 @@ Grzegorz Kotfis
 
 Pål Orby
     github: orby
+
+Sagalpreet Singh
+    github: sagalpreet

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -873,7 +873,7 @@ class AudioSegment(object):
             return out_f
 
         # wav with no ffmpeg parameters can just be written directly to out_f
-        easy_wav = format == "wav" and codec is None and parameters is None
+        easy_wav = format == "wav" and codec is None and parameters is None and tags is None
 
         if easy_wav:
             data = out_f


### PR DESCRIPTION
Tags are being ignored as per the current export behavior of `AudioSegment` for `wav` format.
The fix modifies the `easy_wav` check condition to consider `tags` parameter if specified.