### PR TITLE
fix precision problem of silent

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -464,7 +464,7 @@ class AudioSegment(object):
         Generate a silent audio segment.
         duration specified in milliseconds (default duration: 1000ms, default frame_rate: 11025).
         """
-        frames = int(frame_rate * (duration / 1000.0))
+        frames = int(frame_rate * duration / 1000.0)
         data = b"\0\0" * frames
         return cls(data, metadata={"channels": 1,
                                    "sample_width": 2,


### PR DESCRIPTION
``` python
frame_rate = 16000
duration = 1013
print("Before the pr:", int(frame_rate * (duration / 1000.0)) / frame_rate)
print("After the pr:", int(frame_rate * duration / 1000.0) / frame_rate)
```

```
Before the pr: 1.0129375
After the pr: 1.013
```

If the pr could not be merged, hot fix:

``` python
from pydub import AudioSegment
def silent(cls, duration=1000, frame_rate=11025):
    frames = int(frame_rate * duration / 1000.0)
    data = b"\0\0" * frames
    return cls(data, metadata={"channels": 1,
                                "sample_width": 2,
                                "frame_rate": frame_rate,
                                "frame_width": 2})
AudioSegment.silent = classmethod(silent)
```