### PR TITLE
Fixes #822: stdin is now properly discarded

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -711,7 +711,8 @@ class AudioSegment(object):
         read_ahead_limit = kwargs.get('read_ahead_limit', -1)
         if filename:
             conversion_command += ["-i", filename]
-            stdin_parameter = None
+            # stdin is not required in this mode, can discard it
+            stdin_parameter = subprocess.DEVNULL
             stdin_data = None
         else:
             if cls.converter == 'ffmpeg':


### PR DESCRIPTION
PR to fix the issue #822. 

Previously, stdin was not properly discarded and was set to `None`. In this case, python just inherits the `stdin` from the main process, leading to a deadlock situation explained in the issue above.

In this PR I just discard the `stdin` entirely because it is not being used when the `filename` is provided.