### PR TITLE
Add methods for lin2ulaw, ulaw2lin, lin2alaw, and alaw2lin to pyaudioop.py

### DIFF
--- a/pydub/pyaudioop.py
+++ b/pydub/pyaudioop.py
@@ -529,7 +529,7 @@ def ratecv(cp, size, nchannels, inrate, outrate, state, weightA=1, weightB=0):
             d -= inrate
 
 
-def sign(num):
+def _sign(num):
     return -1 if num < 0 else 0 if num == 0 else 1
 
 
@@ -539,7 +539,7 @@ def lin2ulaw(cp, size):
     
     for i in range(_sample_count(cp, size)):
         sample = _get_sample(cp, size, i)
-        val = sign(sample/maxval)*math.log(1+255*math.abs(sample/maxval))/math.log(1+255)
+        val = _sign(sample/maxval)*math.log(1+255*math.abs(sample/maxval))/math.log(1+255)
         _put_sample(result, size, i, val)
         
     return result
@@ -551,7 +551,7 @@ def ulaw2lin(cp, size):
     
     for i in range(_sample_count(cp, size)):
         sample = _get_sample(cp, size, i)
-        val = (sign(sample)*((1+255)**math.abs(sample)-1)/255) * maxval
+        val = (_sign(sample)*((1+255)**math.abs(sample)-1)/255) * maxval
         _put_sample(result, size, i, val)
         
     return result
@@ -565,9 +565,9 @@ def lin2alaw(cp, size):
         sample = _get_sample(cp, size, i)
         val = None
         if math.abs(sample/maxval) < 1/87.6:
-            val = sign(sample/maxval)*87.6*math.abs(sample/maxval)/(1+math.log(87.6))
+            val = _sign(sample/maxval)*87.6*math.abs(sample/maxval)/(1+math.log(87.6))
         else:
-            val = sign(sample/maxval)*(1+math.log(87.6*math.abs(sample/maxval)))/(1+math.log(87.6)) 
+            val = _sign(sample/maxval)*(1+math.log(87.6*math.abs(sample/maxval)))/(1+math.log(87.6)) 
         _put_sample(result, size, i, val)
         
     return result
@@ -581,9 +581,9 @@ def alaw2lin(cp, size):
         sample = _get_sample(cp, size, i)
         val = None
         if math.abs(sample) < 1/(1+math.log(87.6)):
-            val = sign(sample) * math.abs(sample)*(1+math.log(87.6))/87.6 * maxval
+            val = _sign(sample) * math.abs(sample)*(1+math.log(87.6))/87.6 * maxval
         else:
-            val = sign(sample) * (math.e**(-1+math.abs(sample)*(1+math.log(87.6)))) / 87.6 * maxval
+            val = _sign(sample) * (math.e**(-1+math.abs(sample)*(1+math.log(87.6)))) / 87.6 * maxval
         _put_sample(result, size, i, val)
         
     return result

--- a/pydub/pyaudioop.py
+++ b/pydub/pyaudioop.py
@@ -535,31 +535,31 @@ def sign(num):
 
 def lin2ulaw(cp, size):
     maxval = _get_maxval(size)
-    result = create_string_buffer(len(cp) / size)
+    result = create_string_buffer(len(cp))
     
     for i in range(_sample_count(cp, size)):
         sample = _get_sample(cp, size, i)
         val = sign(sample/maxval)*math.log(1+255*math.abs(sample/maxval))/math.log(1+255)
-        _put_sample(result, 1, i, val)
+        _put_sample(result, size, i, val)
         
     return result
 
 
 def ulaw2lin(cp, size):
-    maxval = _get_maxval(2)
-    result = create_string_buffer(len(cp) / size * 2)
+    maxval = _get_maxval(size)
+    result = create_string_buffer(len(cp))
     
     for i in range(_sample_count(cp, size)):
         sample = _get_sample(cp, size, i)
-        val = (sign(sample)*((1+255)**math.abs(sample)-1)/255)*maxval
-        _put_sample(result, 2, i, val)
+        val = (sign(sample)*((1+255)**math.abs(sample)-1)/255) * maxval
+        _put_sample(result, size, i, val)
         
     return result
 
 
 def lin2alaw(cp, size):
     maxval = _get_maxval(size)
-    result = create_string_buffer(len(cp) / size)
+    result = create_string_buffer(len(cp))
     
     for i in range(_sample_count(cp, size)):
         sample = _get_sample(cp, size, i)
@@ -568,14 +568,14 @@ def lin2alaw(cp, size):
             val = sign(sample/maxval)*87.6*math.abs(sample/maxval)/(1+math.log(87.6))
         else:
             val = sign(sample/maxval)*(1+math.log(87.6*math.abs(sample/maxval)))/(1+math.log(87.6)) 
-        _put_sample(result, 1, i, val)
+        _put_sample(result, size, i, val)
         
     return result
 
 
 def alaw2lin(cp, size):
     maxval = _get_maxval(size)
-    result = create_string_buffer(len(cp) / size * 2)
+    result = create_string_buffer(len(cp))
     
     for i in range(_sample_count(cp, size)):
         sample = _get_sample(cp, size, i)
@@ -583,8 +583,8 @@ def alaw2lin(cp, size):
         if math.abs(sample) < 1/(1+math.log(87.6)):
             val = sign(sample) * math.abs(sample)*(1+math.log(87.6))/87.6 * maxval
         else:
-            val = sign(sample) * (math.e**(-1+math.abs(sample)*(1+math.log(87.6))))/87.6 * maxval
-        _put_sample(result, 1, i, val)
+            val = sign(sample) * (math.e**(-1+math.abs(sample)*(1+math.log(87.6)))) / 87.6 * maxval
+        _put_sample(result, size, i, val)
         
     return result
 

--- a/pydub/pyaudioop.py
+++ b/pydub/pyaudioop.py
@@ -29,7 +29,7 @@ def _check_params(length, size):
 
 
 def _sample_count(cp, size):
-    return len(cp) / size
+    return len(cp) // size
 
 
 def _get_samples(cp, size, signed=True):

--- a/pydub/pyaudioop.py
+++ b/pydub/pyaudioop.py
@@ -529,20 +529,64 @@ def ratecv(cp, size, nchannels, inrate, outrate, state, weightA=1, weightB=0):
             d -= inrate
 
 
+def sign(num):
+    return -1 if num < 0 else 0 if num == 0 else 1
+
+
 def lin2ulaw(cp, size):
-    raise NotImplementedError()
+    maxval = _get_maxval(size)
+    result = create_string_buffer(len(cp) / size)
+    
+    for i in range(_sample_count(cp, size)):
+        sample = _get_sample(cp, size, i)
+        val = sign(sample/maxval)*math.log(1+255*math.abs(sample/maxval))/math.log(1+255)
+        _put_sample(result, 1, i, val)
+        
+    return result
 
 
 def ulaw2lin(cp, size):
-    raise NotImplementedError()
+    maxval = _get_maxval(2)
+    result = create_string_buffer(len(cp) / size * 2)
+    
+    for i in range(_sample_count(cp, size)):
+        sample = _get_sample(cp, size, i)
+        val = (sign(sample)*((1+255)**math.abs(sample)-1)/255)*maxval
+        _put_sample(result, 2, i, val)
+        
+    return result
 
 
 def lin2alaw(cp, size):
-    raise NotImplementedError()
+    maxval = _get_maxval(size)
+    result = create_string_buffer(len(cp) / size)
+    
+    for i in range(_sample_count(cp, size)):
+        sample = _get_sample(cp, size, i)
+        val = None
+        if math.abs(sample/maxval) < 1/87.6:
+            val = sign(sample/maxval)*87.6*math.abs(sample/maxval)/(1+math.log(87.6))
+        else:
+            val = sign(sample/maxval)*(1+math.log(87.6*math.abs(sample/maxval)))/(1+math.log(87.6)) 
+        _put_sample(result, 1, i, val)
+        
+    return result
 
 
 def alaw2lin(cp, size):
-    raise NotImplementedError()
+    maxval = _get_maxval(size)
+    result = create_string_buffer(len(cp) / size * 2)
+    
+    for i in range(_sample_count(cp, size)):
+        sample = _get_sample(cp, size, i)
+        val = None
+        if math.abs(sample) < 1/(1+math.log(87.6)):
+            val = sign(sample) * math.abs(sample)*(1+math.log(87.6))/87.6 * maxval
+        else:
+            val = sign(sample) * (math.e**(-1+math.abs(sample)*(1+math.log(87.6))))/87.6 * maxval
+        _put_sample(result, 1, i, val)
+        
+    return result
 
 
 def lin2adpcm(cp, size, state):


### PR DESCRIPTION
As described in

https://web.archive.org/web/20110719132013/http://hazelware.luggle.com/tutorials/mulawcompression.html

for the compression algorithms accordingly, the expansion algorithms are just an inverse of this