### PR TITLE
fix import of local pyaudioop if audioop is missing (python > 3.12)

### DIFF
--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -14,7 +14,7 @@ from functools import wraps
 try:
     import audioop
 except ImportError:
-    import pyaudioop as audioop
+    from . import pyaudioop as audioop
 
 if sys.version_info >= (3, 0):
     basestring = str


### PR DESCRIPTION
pozalabs-pydub can be run on python 3.13 if the import on utils.py is fixed