### PR TITLE
Use relative import for `pyaudioop` fallback

### DIFF
--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -14,7 +14,7 @@ from functools import wraps
 try:
     import audioop
 except ImportError:
-    import pyaudioop as audioop
+    from . import pyaudioop as audioop
 
 if sys.version_info >= (3, 0):
     basestring = str


### PR DESCRIPTION
This resolves an [`ImportError` from this comment](https://github.com/jiaaro/pydub/issues/725#issuecomment-2865696154).