### PR TITLE
Fix Windows permissions access Issue while using 'ffmepg ffmplay' command.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,3 +99,6 @@ Grzegorz Kotfis
 
 Pål Orby
     github: orby
+
+Carlos Bazaga
+    github: carbaz

--- a/pydub/playback.py
+++ b/pydub/playback.py
@@ -9,9 +9,9 @@ import subprocess
 from tempfile import NamedTemporaryFile
 from .utils import get_player_name, make_chunks
 
-def _play_with_ffplay(seg):
+def _play_with_ffplay(seg, temp=None, delete=True):
     PLAYER = get_player_name()
-    with NamedTemporaryFile("w+b", suffix=".wav") as f:
+    with NamedTemporaryFile("w+b", suffix=".wav", dir=temp, delete=delete) as f:
         seg.export(f.name, "wav")
         subprocess.call([PLAYER, "-nodisp", "-autoexit", "-hide_banner", f.name])
 
@@ -48,7 +48,20 @@ def _play_with_simpleaudio(seg):
     )
 
 
-def play(audio_segment):
+def play(audio_segment, temp=None, delete=True):
+    """Plays an audio segment.
+
+    Args:
+        audio_segment: The audio segment to play. This could be a pydub
+                       AudioSegment object or a path to an audio file.
+        temp (str, optional): While using the 'ffmpeg' player.
+                              A path to a temporary file where the audio segment
+                              will be saved before playing. If None, a default
+                              temporary file location will be used. Defaults to None.
+        delete (bool, optional): While using the 'ffmpeg' player.
+                                 If True, the temporary audio file will be
+                                 deleted after playback. Defaults to True.
+    """
     try:
         playback = _play_with_simpleaudio(audio_segment)
         try:
@@ -62,10 +75,9 @@ def play(audio_segment):
 
     try:
         _play_with_pyaudio(audio_segment)
-        return
     except ImportError:
         pass
     else:
         return
 
-    _play_with_ffplay(audio_segment)
+    _play_with_ffplay(audio_segment, temp, delete)


### PR DESCRIPTION
The widely reported "permissions" issues with "play" while using `ffmplay` player under windows is directly related to how `NamedTemporaryFile` creates and deletes the temporal file, not allowing it to be accessed from a subprocess, which is what  `_play_with_ffplay` function does in the end.

Also, the widely suggested workaround is to modify locally the "pydub" library to set the `NamedTemporaryFile` call `delete` parameter to `False`.
( No one should like to modify dependencies locally 😠 )

To avoid the need to modify the library code locally best approach is allow users to set this "delete" behavior on call.

As setting it to `False` will lead to non deleted temporal files left over it's interesting to let the user also choose the temporal folder to store them so he can deal with leftover temporal files later or whatever.

Finally I documented the new two parameters specifying the will work only while using `ffmpeg` library.