### PR TITLE
Security: Executable search includes current directory, enabling binary hijacking

### DIFF
--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -153,7 +153,7 @@ def which(program):
     if os.name == "nt" and not program.endswith(".exe"):
         program += ".exe"
 
-    envdir_list = [os.curdir] + os.environ["PATH"].split(os.pathsep)
+    envdir_list = os.environ.get("PATH", "").split(os.pathsep)
 
     for envdir in envdir_list:
         program_path = os.path.join(envdir, program)


### PR DESCRIPTION
## Problem

The `which()` helper prepends `os.curdir` to the search path. Functions like `get_encoder_name()`, `get_player_name()`, and `get_prober_name()` use this result to launch external tools (`ffmpeg`/`ffprobe`/`ffplay` variants). If the process runs in an attacker-controlled working directory, a malicious executable with one of those names can be executed.

**Severity**: `high`
**File**: `pydub/utils.py`

## Solution

Do not search `.` by default. Resolve executables from a trusted allowlist of absolute paths, or use `shutil.which()` against a sanitized PATH that excludes the current directory. Optionally verify binary signatures/ownership before execution.

## Changes

- `pydub/utils.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
