### PR TITLE
fix: use if-statement with raise instead of assert on 'pydub/silence.py'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,3 +99,6 @@ Grzegorz Kotfis
 
 Pål Orby
     github: orby
+
+Manuel Rubio
+    github: rxxbyy

--- a/pydub/silence.py
+++ b/pydub/silence.py
@@ -172,7 +172,10 @@ def detect_leading_silence(sound, silence_threshold=-50.0, chunk_size=10):
     chunk_size - chunk size for interating over the segment in ms
     """
     trim_ms = 0 # ms
-    assert chunk_size > 0 # to avoid infinite loop
+
+    if chunk_size <= 0: # to avoid infinite loop
+        raise ValueError("`chunk_size` must be greater than zero to avoid an infinite loop.")
+
     while sound[trim_ms:trim_ms+chunk_size].dBFS < silence_threshold and trim_ms < len(sound):
         trim_ms += chunk_size
 


### PR DESCRIPTION
`assert` can be disabled on a environment with optimizations enabled which cause assert statements to emit no code causing the infinite loop guard to be silently ignored. ([https://docs.python.org/3/reference/simple_stmts.html#index-18](https://docs.python.org/3/reference/simple_stmts.html#index-18))