### PR TITLE
Improve error when converter is unset

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -558,6 +558,13 @@ class AudioSegment(object):
             else:
                 return obj[start_second * 1000:(start_second + duration) * 1000]
 
+        if cls.converter is None:
+            raise OSError(
+                "AudioSegment.converter is not set. Check that ffmpeg or "
+                "avconv is installed and that AudioSegment.converter is "
+                "configured."
+            )
+
         input_file = NamedTemporaryFile(mode='wb', delete=False)
         try:
             input_file.write(file.read())
@@ -694,6 +701,13 @@ class AudioSegment(object):
                 return cls(data=file.read(), metadata=metadata)[:duration*1000]
             else:
                 return cls(data=file.read(), metadata=metadata)[start_second*1000:(start_second+duration)*1000]
+
+        if cls.converter is None:
+            raise OSError(
+                "AudioSegment.converter is not set. Check that ffmpeg or "
+                "avconv is installed and that AudioSegment.converter is "
+                "configured."
+            )
 
         conversion_command = [cls.converter,
                               '-y',  # always overwrite existing files

--- a/test/test.py
+++ b/test/test.py
@@ -1251,6 +1251,13 @@ class NoConverterTests(unittest.TestCase):
         func = partial(AudioSegment.from_file, self.mp3_file, format="mp3")
         self.assertRaises(OSError, func)
 
+    def test_opening_mp3_file_with_unset_converter_has_context(self):
+        AudioSegment.converter = None
+        func = partial(AudioSegment.from_file, self.mp3_file, format="mp3")
+
+        with self.assertRaisesRegexp(OSError, "AudioSegment.converter is not set"):
+            func()
+
     def test_init_AudioSegment_data_buffer(self):
         seg = AudioSegment(data="\0" * 34, sample_width=2, frame_rate=4, channels=1)
 


### PR DESCRIPTION
## Summary

Raise an actionable `OSError` when `AudioSegment.converter` is unset instead of letting `subprocess.Popen()` fail with a generic `NoneType` path error.

Fixes #853.

## Changes

- Adds an explicit `AudioSegment.converter is not set` check before invoking ffmpeg/avconv in `from_file()` and `from_file_using_temporary_files()`.
- Adds a regression test for `AudioSegment.from_file(..., format=mp3)` when `AudioSegment.converter` is `None`.

## Validation

Not run locally.

Static validation performed:

- `git diff --check`