### PR TITLE
Reject unreasonable WAV header values

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -88,6 +88,10 @@ WavSubChunk = namedtuple('WavSubChunk', ['id', 'position', 'size'])
 WavData = namedtuple('WavData', ['audio_format', 'channels', 'sample_rate',
                                  'bits_per_sample', 'raw_data'])
 
+MAX_WAV_SAMPLE_RATE = 384000
+MAX_WAV_CHANNELS = 8
+MAX_WAV_BITS_PER_SAMPLE = 64
+
 
 def extract_wav_headers(data):
     # def search_subchunk(data, subchunk_id):
@@ -122,6 +126,17 @@ def read_wav_audio(data, headers=None):
     channels = struct.unpack_from('<H', data[pos + 2:pos + 4])[0]
     sample_rate = struct.unpack_from('<I', data[pos + 4:pos + 8])[0]
     bits_per_sample = struct.unpack_from('<H', data[pos + 14:pos + 16])[0]
+    if not 1 <= channels <= MAX_WAV_CHANNELS:
+        raise CouldntDecodeError("Invalid channel count %s in wav data" %
+                                 channels)
+    if not 1 <= sample_rate <= MAX_WAV_SAMPLE_RATE:
+        raise CouldntDecodeError("Invalid sample rate %s in wav data" %
+                                 sample_rate)
+    if (bits_per_sample < 8 or
+            bits_per_sample > MAX_WAV_BITS_PER_SAMPLE or
+            bits_per_sample % 8 != 0):
+        raise CouldntDecodeError("Invalid bit depth %s in wav data" %
+                                 bits_per_sample)
 
     data_hdr = headers[-1]
     if data_hdr.id != b'data':

--- a/test/test.py
+++ b/test/test.py
@@ -231,6 +231,31 @@ class AudioSegmentTests(unittest.TestCase):
         self.assertEqual(seg.sample_width, 2)
         self.assertEqual(seg.frame_rate, 32000)
 
+    def _wav_header_with(self, offset, replacement):
+        wav_data = (
+            b'RIFF\x28\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x02\x00'
+            b'\x00}\x00\x00\x00\xf4\x01\x00\x04\x00\x10\x00data\x04\x00'
+            b'\x00\x00\x00\x00\x00\x00\x00')
+        return wav_data[:offset] + replacement + wav_data[offset + len(replacement):]
+
+    def test_wav_with_unreasonable_sample_rate_fails(self):
+        wav_data = self._wav_header_with(24, struct.pack('<I', 100000000))
+
+        with self.assertRaises(CouldntDecodeError):
+            AudioSegment(wav_data)
+
+    def test_wav_with_unreasonable_channel_count_fails(self):
+        wav_data = self._wav_header_with(22, struct.pack('<H', 65535))
+
+        with self.assertRaises(CouldntDecodeError):
+            AudioSegment(wav_data)
+
+    def test_wav_with_unreasonable_bit_depth_fails(self):
+        wav_data = self._wav_header_with(34, struct.pack('<H', 65535))
+
+        with self.assertRaises(CouldntDecodeError):
+            AudioSegment(wav_data)
+
     def test_24_bit_audio(self):
         path24 = os.path.join(data_dir, 'test1-24bit.wav')
         seg24 = AudioSegment._from_safe_wav(path24)


### PR DESCRIPTION
## Summary

Reject WAV files with unreasonable header metadata before returning an `AudioSegment`.

Fixes #877.

## Changes

- Adds bounds checks for WAV channel count, sample rate, and bit depth in `read_wav_audio()`.
- Keeps existing 64-bit WAV support while rejecting extreme values such as 100MHz sample rates, 65k channels, or 65k-bit samples.
- Adds regression coverage using synthetic WAV headers for each invalid metadata field.

## Validation

Not run locally.

Static validation performed:

- `git diff --check`