### PR TITLE
Fix bare except clauses with specific exception types

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -14,14 +14,14 @@ from collections import namedtuple
 
 try:
     from StringIO import StringIO
-except:
+except ImportError:
     from io import StringIO
 
 from io import BytesIO
 
 try:
     from itertools import izip
-except:
+except ImportError:
     izip = zip
 
 from .utils import (
@@ -186,7 +186,7 @@ class AudioSegment(object):
         if isinstance(data, array.array):
             try:
                 data = data.tobytes()
-            except:
+            except AttributeError:
                 data = data.tostring()
 
         # prevent partial specification of arguments

--- a/pydub/generators.py
+++ b/pydub/generators.py
@@ -47,7 +47,7 @@ class SignalGenerator(object):
         
         try:
             data = data.tobytes()
-        except:
+        except AttributeError:
             data = data.tostring()
 
         return AudioSegment(data=data, metadata={

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -377,7 +377,7 @@ def cache_codecs(function):
     def wrapper():
         try:
             return cache[0]
-        except:
+        except KeyError:
             cache[0] = function()
             return cache[0]
 


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types to avoid accidentally catching `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`.

- `pydub/utils.py`: `except:` → `except KeyError:` (cache dict access)
- `pydub/audio_segment.py`: `except:` → `except ImportError:` (Python 2/3 compat imports), `except AttributeError:` (tobytes/tostring compat)
- `pydub/generators.py`: `except:` → `except AttributeError:` (tobytes/tostring compat)